### PR TITLE
Add originalError wrapping support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
+- '11'
 - '10'
+- '8'
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
 - '11'
 - '10'
-- '8'
 cache:
   directories:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --no-config --write src/**/*.ts",
     "check-format": "prettier --no-config -l src/**/*.ts",
     "lint": "tslint --project .",
+    "lint-fix": "tslint --project . --fix",
     "build": "tsc",
     "test": "jest",
     "codecov": "codecov"

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -1,0 +1,46 @@
+import {
+  GraphQLError,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  parse
+} from "graphql";
+import { compileQuery } from "../execution";
+
+const error = new Error("original");
+const schema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: "TestType",
+    fields: {
+      a: {
+        type: GraphQLString,
+        resolve() {
+          return "a";
+        }
+      },
+      b: {
+        type: GraphQLString,
+        resolve() {
+          throw error;
+        }
+      }
+    }
+  })
+});
+
+function executeTestQuery(query: string) {
+  const ast = parse(query);
+  const compiled: any = compileQuery(schema, ast, "");
+  return compiled.query({}, undefined, {});
+}
+
+describe("error generation", () => {
+  test("includes original error", () => {
+    const resp = executeTestQuery("{ b }");
+    expect(resp.errors[0].originalError).toBe(error);
+  });
+  test("is instanceOf upstream error", () => {
+    const resp = executeTestQuery("{ b }");
+    expect(resp.errors[0] instanceof GraphQLError).toBeTruthy();
+  });
+});

--- a/src/__tests__/variables.test.ts
+++ b/src/__tests__/variables.test.ts
@@ -285,9 +285,14 @@ describe("Execute: Handles inputs", () => {
           }
         `);
 
+        const noVal = Object.create(null);
+        noVal.a = "foo";
+        noVal.b = ["bar"];
+        noVal.c = "baz";
+
         expect(result).toEqual({
           data: {
-            fieldWithObjectInput: "{ a: 'foo', b: [ 'bar' ], c: 'baz' }"
+            fieldWithObjectInput: inspect(noVal)
           }
         });
       });
@@ -667,8 +672,7 @@ describe("Execute: Handles inputs", () => {
             message:
               'Variable "$value" got invalid value [ 1, 2, 3 ]; ' +
               "Expected type String; String cannot represent a non string value: [1, 2, 3]",
-            locations: [{ line: 2, column: 16 }],
-            path: undefined
+            locations: [{ line: 2, column: 16 }]
           }
         ]
       });

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -288,9 +288,7 @@ export function getArgumentDefs(
         // execution. This is a runtime check to ensure execution does not
         // continue with an invalid argument value.
         throw new GraphQLError(
-          `Argument "${name}" of type \"${inspect(
-            argType
-          )}\" has invalid value ${print(argumentNode.value)}.`,
+          `Argument "${name}" of type \"${argType}\" has invalid value ${print(argumentNode.value)}.`,
           [argumentNode.value]
         );
       }
@@ -311,9 +309,9 @@ export function getArgumentDefs(
       throw new GraphQLError(
         argumentNode
           ? `Argument "${name}" of non-null type ` +
-            `"${inspect(argType)}" must not be null.`
+            `"${argType}" must not be null.`
           : `Argument "${name}" of required type ` +
-            `"${inspect(argType)}" was not provided.`,
+            `"${argType}" was not provided.`,
         [node]
       );
     }
@@ -376,7 +374,7 @@ export function getVariableValues(
         new GraphQLError(
           `Variable "$${varName}" expected value of type ` +
             `"${
-              varType ? inspect(varType) : print(varDefNode.type)
+              varType ? varType : print(varDefNode.type)
             }" which cannot be used as an input type.`,
           [varDefNode.type]
         )
@@ -395,9 +393,9 @@ export function getVariableValues(
           new GraphQLError(
             hasValue
               ? `Variable "$${varName}" of non-null type ` +
-                `"${inspect(varType)}" must not be null.`
+                `"${varType}" must not be null.`
               : `Variable "$${varName}" of required type ` +
-                `"${inspect(varType)}" was not provided.`,
+                `"${varType}" was not provided.`,
             [varDefNode]
           )
         );

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+
+import {printError, SourceLocation, GraphQLError as UpstreamGraphQLError} from "graphql";
+
+export function GraphQLError(
+        message: string,
+        locations?: ReadonlyArray<SourceLocation>,
+        path?: ReadonlyArray<string | number>,
+        originalError?: Error & { extensions?: any }
+    ) {
+        const extensions = originalError && originalError.extensions;
+        Object.defineProperties(this, {
+            message: {
+                value: message,
+                enumerable: true,
+            },
+            locations: {
+                value: locations || undefined,
+                enumerable: Boolean(locations),
+            },
+            path: {
+                value: path || undefined,
+                enumerable: Boolean(path),
+            },
+            originalError: {
+                value: originalError,
+            },
+            extensions: {
+                // Coercing falsey values to undefined ensures they will not be included
+                // in JSON.stringify() when not provided.
+                value: extensions || undefined,
+                enumerable: Boolean(extensions),
+            },
+        });
+
+        // Include (non-enumerable) stack trace.
+        if (originalError && originalError.stack) {
+            Object.defineProperty(this, 'stack', {
+                value: originalError.stack,
+                writable: true,
+                configurable: true,
+            });
+        } else if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, GraphQLError);
+        } else {
+            Object.defineProperty(this, 'stack', {
+                value: Error().stack,
+                writable: true,
+                configurable: true,
+            });
+        }
+}
+
+(GraphQLError as any).prototype = Object.create(UpstreamGraphQLError.prototype, {
+    constructor: { value: GraphQLError },
+    name: { value: 'GraphQLError' },
+    toString: {
+        value: function toString() {
+            return printError(this);
+        },
+    },
+});

--- a/src/error.ts
+++ b/src/error.ts
@@ -7,8 +7,7 @@
  * @flow strict
  */
 
-
-import {printError, SourceLocation, GraphQLError as UpstreamGraphQLError} from "graphql";
+import {GraphQLError as UpstreamGraphQLError, printError, SourceLocation} from "graphql";
 
 export function GraphQLError(
         message: string,
@@ -43,7 +42,7 @@ export function GraphQLError(
 
         // Include (non-enumerable) stack trace.
         if (originalError && originalError.stack) {
-            Object.defineProperty(this, 'stack', {
+            Object.defineProperty(this, "stack", {
                 value: originalError.stack,
                 writable: true,
                 configurable: true,
@@ -51,7 +50,7 @@ export function GraphQLError(
         } else if (Error.captureStackTrace) {
             Error.captureStackTrace(this, GraphQLError);
         } else {
-            Object.defineProperty(this, 'stack', {
+            Object.defineProperty(this, "stack", {
                 value: Error().stack,
                 writable: true,
                 configurable: true,
@@ -61,7 +60,7 @@ export function GraphQLError(
 
 (GraphQLError as any).prototype = Object.create(UpstreamGraphQLError.prototype, {
     constructor: { value: GraphQLError },
-    name: { value: 'GraphQLError' },
+    name: { value: "GraphQLError" },
     toString: {
         value: function toString() {
             return printError(this);

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -42,6 +42,7 @@ import {
 } from "./ast";
 import { queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
+import {GraphQLError as CustomGraphQLError} from "./error";
 
 /**
  * The result of GraphQL execution.
@@ -277,6 +278,7 @@ export function createBoundQuery(
             executor,
             resolveIfDone,
             safeMap,
+            CustomGraphQLError,
             ...resolvers
         ]);
         if (result) {
@@ -1223,7 +1225,7 @@ function buildCompilationContext(
         depth: 0,
         variableValues: {},
         fieldResolver: undefined as any,
-        errors
+        errors: errors as any
     };
 }
 
@@ -1237,10 +1239,10 @@ function getErrorObject(
     nodes: FieldNode[],
     path: ResponsePath,
     message: string,
-    extensionsObject?: string
+    originalError?: string
 ): string {
     const locations = computeLocations(nodes);
-    if (!extensionsObject) {
+    if (!originalError) {
         return `{
         message: ${message},
         locations: ${locations ? JSON.stringify(locations) : "undefined"},
@@ -1248,16 +1250,10 @@ function getErrorObject(
       }`;
     }
 
-    return `${extensionsObject} && ${extensionsObject}.extensions ? {
-        message: ${message},
-        locations: ${locations ? JSON.stringify(locations) : "undefined"},
-        path: ${serializeResponsePathAsArray(path)},
-        extensions: ${extensionsObject}.extensions
-      } : {
-        message: ${message},
-        locations: ${locations ? JSON.stringify(locations) : "undefined"},
-        path: ${serializeResponsePathAsArray(path)},
-      }`;
+    return `new GraphQLError(${message}, 
+    ${locations ? JSON.stringify(locations) : "undefined"},
+      ${serializeResponsePathAsArray(path)},
+      ${originalError})`;
 }
 
 function getResolverName(parentName: string, name: string) {
@@ -1280,7 +1276,7 @@ function getSerializerName(name: string) {
 function getFunctionSignature(context: CompilationContext) {
     return `return function query (
   ${GLOBAL_ROOT_NAME}, ${GLOBAL_CONTEXT_NAME}, ${GLOBAL_VARIABLES_NAME}, ${GLOBAL_EXECUTOR_NAME},
-   __resolveIfDone, __safeMap,
+   __resolveIfDone, __safeMap, GraphQLError,
     ${getResolversVariablesName(context)})`;
 }
 
@@ -1463,9 +1459,7 @@ function normalizeErrors(err: Error[] | Error): GraphQLFormattedError[] {
 }
 
 function normalizeError(err: Error): GraphQLFormattedError {
-    return formatError(
-        err instanceof GraphQLError ? err : new GraphQLError(err.message)
-    );
+    return err instanceof GraphQLError ? err : new (CustomGraphQLError as any)(err.message, (err as any).locations, (err as any).path, err);
 }
 
 /**

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -40,9 +40,9 @@ import {
     getVariableValues,
     resolveFieldDef
 } from "./ast";
+import {GraphQLError as CustomGraphQLError} from "./error";
 import { queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
-import {GraphQLError as CustomGraphQLError} from "./error";
 
 /**
  * The result of GraphQL execution.
@@ -1250,7 +1250,7 @@ function getErrorObject(
       }`;
     }
 
-    return `new GraphQLError(${message}, 
+    return `new GraphQLError(${message},
     ${locations ? JSON.stringify(locations) : "undefined"},
       ${serializeResponsePathAsArray(path)},
       ${originalError})`;
@@ -1459,7 +1459,8 @@ function normalizeErrors(err: Error[] | Error): GraphQLFormattedError[] {
 }
 
 function normalizeError(err: Error): GraphQLFormattedError {
-    return err instanceof GraphQLError ? err : new (CustomGraphQLError as any)(err.message, (err as any).locations, (err as any).path, err);
+    return err instanceof GraphQLError ? err :
+        new (CustomGraphQLError as any)(err.message, (err as any).locations, (err as any).path, err);
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "noEmitOnError": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
+    "noImplicitThis": false,
     "moduleResolution": "node",
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
We now create a custom error that capture the original one like in graphql-js.

Closes #2.