### PR TITLE
Custom serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const LRU = require("lru-cache");
 const {compileQuery} = require("graphql-jit");
 
 
-module.exports = function setupHandler(schema, disableLeafSerialization) {
+module.exports = function setupHandler(schema) {
     const cache = LRU({max: 100});
     return function graphqlMiddleware(request, response) {
         // Promises are used as a mechanism for capturing any thrown errors during
@@ -103,7 +103,7 @@ module.exports = function setupHandler(schema, disableLeafSerialization) {
                     }
                 }
 
-                cached = compileQuery(schema, documentAST, operationName, {disableLeafSerialization});
+                cached = compileQuery(schema, documentAST, operationName, {customSerializers: {ID: String, String: String}});
                 cache.set(query + operationName, cached)
             }
 
@@ -160,6 +160,8 @@ Compiles the `document` AST, using an optional operationName and  compiler optio
 
   - `disableLeafSerialization` {boolean, default: false} - disables leaf node serializers. The serializers validate the content of the field 
   so this option should only be set to true if there are strong assurances that the values are valid.
+  - `customSerializers` {Object as Map, default: {}} - Replace serializer functions for specific types. Can be used as a safer alternative 
+  for overly expensive 
   - `customJSONSerializer` {boolean, default: false} - Whether to produce also a JSON serializer function using `fast-json-stringify`,
   otherwise the stringify function is just `JSON.stringify` 
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,14 @@
     "testRegex": "(/tests/.*|(\\.|/)test)\\.ts$",
     "transform": {
       "^.+\\.ts$": "ts-jest"
+    },
+    "coverageThreshold": {
+      "global": {
+        "branches": 87,
+        "functions": 93,
+        "lines": 93,
+        "statements": 93
+      }
     }
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/__benchmarks__/schema.benchmark.ts
+++ b/src/__benchmarks__/schema.benchmark.ts
@@ -50,7 +50,14 @@ fragment articleFields on Article {
 `);
 
 const { query: withLeaf }: any = compileQuery(schema, document, "", {
-  disableLeafSerialization: false
+  disableLeafSerialization: false,
+  customSerializers: {
+    String: String,
+    ID: String,
+    Boolean: Boolean,
+    Int: Number,
+    Float: Number
+  }
 });
 const { query: noLeaf }: any = compileQuery(schema, document, "", {
   disableLeafSerialization: true

--- a/src/__tests__/scalars.test.ts
+++ b/src/__tests__/scalars.test.ts
@@ -220,6 +220,23 @@ describe("Scalars: Is able to serialize custom scalar", () => {
         });
         expect(GraphQLString.serialize).not.toHaveBeenCalledWith("test");
       });
+      test("custom serializer is called", () => {
+        const customSerializer = jest.fn(String);
+        const prepared: any = compileQuery(
+          setupSchema(GraphQLString, "test"),
+          parse("{scalar}"),
+          "",
+          { customSerializers: { String: customSerializer } }
+        );
+        const result = prepared.query(undefined, undefined, {});
+        expect(result).toEqual({
+          data: {
+            scalar: "test"
+          }
+        });
+        expect(GraphQLString.serialize).not.toHaveBeenCalledWith("test");
+        expect(customSerializer).toHaveBeenCalledWith("test");
+      });
     });
   });
 });

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -67,7 +67,7 @@ export interface CompilerOptions {
 
     // Map of serializers to override
     // the key should be the name passed to the Scalar or Enum type
-    customSerializers: { [key: string]: (v: any) => any}
+    customSerializers: { [key: string]: (v: any) => any};
 }
 
 /**
@@ -541,7 +541,8 @@ function compileLeafType(
     ) {
         body += `${originPaths.join(".")}`;
     } else {
-        context.dependencies.set(getSerializerName(type.name), getSerializer(type, context.options.customSerializers[type.name]));
+        context.dependencies.set(getSerializerName(type.name),
+            getSerializer(type, context.options.customSerializers[type.name]));
         body += getSerializerName(type.name);
         body += `(${originPaths.join(
             "."


### PR DESCRIPTION
graphql-js 14 introduces stricter (and with more feature) serialization functions which although nice, they are overkill for the majority of cases.

This PR introduces a simple custom serialization replacement based on the type names.
