### PR TITLE
fix: arguments type for compiled function

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -209,7 +209,7 @@ export function isCompiledQuery<
 export function createBoundQuery(
     context: CompilationContext,
     document: DocumentNode,
-    func: () => any
+    func: (...args: any[]) => any
 ) {
     const {
         schema,


### PR DESCRIPTION
Fixes type errors in the editor configured with latest typescript which includes types for call, bind and apply - at `func.apply(null, [...])`