### PR TITLE
Compile variable parsing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     },
     "coverageThreshold": {
       "global": {
-        "branches": 87,
+        "branches": 88,
         "functions": 93,
-        "lines": 93,
-        "statements": 93
+        "lines": 95,
+        "statements": 95
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     },
     "coverageThreshold": {
       "global": {
-        "branches": 89,
-        "functions": 93,
+        "branches": 90,
+        "functions": 94,
         "lines": 95,
         "statements": 95
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git@github.com:ruiaraujo/graphql-jit.git"
   },
   "scripts": {
+    "precommit": "lint-staged",
     "prepublishOnly": "yarn && yarn build",
     "format": "prettier --no-config --write src/**/*.ts",
     "check-format": "prettier --no-config -l src/**/*.ts",
@@ -44,19 +45,20 @@
     }
   },
   "peerDependencies": {
-    "graphql": "^14.0.2"
+    "graphql": ">=14"
   },
   "devDependencies": {
     "@types/benchmark": "^1.0.31",
-    "@types/graphql": "^14.0.3",
+    "@types/graphql": "^14.2.0",
     "@types/jest": "^23.3.5",
     "@types/json-schema": "^7.0.1",
     "@types/lodash.merge": "^4.6.4",
     "@types/node": "^10.11.7",
     "benchmark": "^2.1.4",
     "codecov": "^3.1.0",
-    "graphql": "^14.0.2",
+    "graphql": "^14.2.1",
     "jest": "^23.6.0",
+    "lint-staged": "^8.1.5",
     "prettier": "^1.14.3",
     "ts-jest": "^23.10.4",
     "ts-node": "^7.0.1",
@@ -66,8 +68,21 @@
     "typescript": "^3.1.3"
   },
   "dependencies": {
-    "fast-json-stringify": "^1.9.1",
+    "fast-json-stringify": "^1.13.0",
     "json-schema": "^0.2.3",
     "lodash.merge": "^4.6.1"
+  },
+  "lint-staged": {
+    "linters": {
+      "*.ts": [
+        "tslint -c tslint.json -p tsconfig.json --fix",
+        "prettier --no-config --write",
+        "git add"
+      ],
+      "*.{graphql,js,md,json,yaml,yml}": [
+        "prettier --no-config --write",
+        "git add"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
@@ -36,7 +36,7 @@
     },
     "coverageThreshold": {
       "global": {
-        "branches": 88,
+        "branches": 89,
         "functions": 93,
         "lines": 95,
         "statements": 95

--- a/src/__benchmarks__/schema-variables.benchmark.ts
+++ b/src/__benchmarks__/schema-variables.benchmark.ts
@@ -54,12 +54,10 @@ const { query: compilerParserNoLeaf }: any = compileQuery(
   document,
   "",
   {
-    enableVariableCompilation: true,
     disableLeafSerialization: true
   }
 );
 const compilerParser: any = compileQuery(schema, document, "", {
-  enableVariableCompilation: true,
   customSerializers: {
     String: String,
     ID: String,
@@ -67,20 +65,6 @@ const compilerParser: any = compileQuery(schema, document, "", {
     Int: Number,
     Float: Number
   }
-});
-const { query: defaultParser }: any = compileQuery(schema, document, "", {
-  enableVariableCompilation: false,
-  customSerializers: {
-    String: String,
-    ID: String,
-    Boolean: Boolean,
-    Int: Number,
-    Float: Number
-  }
-});
-const { query: defaultParserNoLeaf }: any = compileQuery(schema, document, "", {
-  enableVariableCompilation: false,
-  disableLeafSerialization: true
 });
 const vars = { id: "1" };
 
@@ -94,21 +78,7 @@ suite
       p.then(() => deferred.resolve());
     }
   })
-  .add("graphql-jit - default", {
-    defer: true,
-    fn(deferred: any) {
-      defaultParser(undefined, undefined, vars).then(() => deferred.resolve());
-    }
-  })
-  .add("graphql-jit - default no leaf", {
-    defer: true,
-    fn(deferred: any) {
-      defaultParserNoLeaf(undefined, undefined, vars).then(() =>
-        deferred.resolve()
-      );
-    }
-  })
-  .add("graphql-jit - compiled", {
+  .add("graphql-jit", {
     defer: true,
     fn(deferred: any) {
       compilerParser
@@ -116,7 +86,7 @@ suite
         .then(() => deferred.resolve());
     }
   })
-  .add("graphql-jit - compiled no leaf", {
+  .add("graphql-jit - no leaf", {
     defer: true,
     fn(deferred: any) {
       compilerParserNoLeaf(undefined, undefined, vars).then(() =>

--- a/src/__benchmarks__/schema-variables.benchmark.ts
+++ b/src/__benchmarks__/schema-variables.benchmark.ts
@@ -1,0 +1,223 @@
+import Benchmark from "benchmark";
+import {
+  execute,
+  // execute,
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  parse
+} from "graphql";
+import { compileQuery } from "../";
+
+const schema = getSchema();
+const document = parse(`
+query ($id: ID! = "1", $width: Int = 640, $height: Int = 480){
+  feed {
+    id,
+    title
+  },
+  article(id: $id) {
+    ...articleFields,
+    author {
+      id,
+      name,
+      pic(width: $width, height: $height) {
+        url,
+        width,
+        height
+      },
+      recentArticle {
+        ...articleFields,
+        keywords
+      }
+    }
+  }
+}
+
+fragment articleFields on Article {
+  id,
+  isPublished,
+  title,
+  body,
+  hidden,
+  notdefined
+}
+`);
+
+const { query: compilerParserNoLeaf }: any = compileQuery(schema, document, "", {
+  enableVariableCompilation: true,
+  disableLeafSerialization: true
+});
+const compilerParser: any = compileQuery(schema, document, "", {
+  enableVariableCompilation: true,
+  customSerializers: {
+    String: String,
+    ID: String,
+    Boolean: Boolean,
+    Int: Number,
+    Float: Number
+  }
+});
+const { query: defaultParser }: any = compileQuery(schema, document, "", {
+  enableVariableCompilation: false,
+  customSerializers: {
+    String: String,
+    ID: String,
+    Boolean: Boolean,
+    Int: Number,
+    Float: Number
+  }
+});
+const { query: defaultParserNoLeaf }: any = compileQuery(schema, document, "", {
+  enableVariableCompilation: false,
+  disableLeafSerialization: true
+});
+const vars = {id: "1"};
+
+const suite = new Benchmark.Suite();
+
+suite
+  .add("graphql-js", {
+    defer: true,
+    fn(deferred: any) {
+      const p: any = execute(schema, document, undefined,undefined, vars);
+      p.then(() => deferred.resolve());
+    }
+  })
+    .add("graphql-jit - default", {
+      defer: true,
+      fn(deferred: any) {
+        defaultParser(undefined, undefined, vars).then(() => deferred.resolve());
+      }
+    })
+    .add("graphql-jit - default no leaf", {
+      defer: true,
+      fn(deferred: any) {
+        defaultParserNoLeaf(undefined, undefined, vars).then(() => deferred.resolve());
+      }
+    })
+    .add("graphql-jit - compiled", {
+      defer: true,
+      fn(deferred: any) {
+        compilerParser.query(undefined, undefined, vars).then(() => deferred.resolve());
+      }
+    })
+    .add("graphql-jit - compiled no leaf", {
+      defer: true,
+      fn(deferred: any) {
+        compilerParserNoLeaf(undefined, undefined, vars).then(() => deferred.resolve());
+      }
+    })
+  // add listeners
+  .on("cycle", (event: any) => {
+    // tslint:disable-next-line
+    console.log(String(event.target));
+  })
+  .on("complete", () => {
+    // tslint:disable-next-line
+    console.log("Fastest is " + suite.filter("fastest").map("name" as any));
+  })
+  .run();
+
+function getSchema() {
+  const BlogImage = new GraphQLObjectType({
+    name: "Image",
+    fields: {
+      url: { type: GraphQLString },
+      width: { type: GraphQLInt },
+      height: { type: GraphQLInt }
+    }
+  });
+
+  const BlogAuthor = new GraphQLObjectType({
+    name: "Author",
+    fields: () => ({
+      id: { type: GraphQLString },
+      name: { type: GraphQLString },
+      pic: {
+        args: { width: { type: GraphQLInt }, height: { type: GraphQLInt } },
+        type: BlogImage,
+        resolve: (obj, { width, height }) => obj.pic(width, height)
+      },
+      recentArticle: { type: BlogArticle }
+    })
+  });
+
+  const BlogArticle: GraphQLObjectType = new GraphQLObjectType({
+    name: "Article",
+    fields: {
+      id: { type: new GraphQLNonNull(GraphQLID) },
+      isPublished: { type: GraphQLBoolean },
+      author: { type: BlogAuthor },
+      title: {
+        type: GraphQLString,
+        resolve: article => Promise.resolve(article && article.title)
+      },
+      body: { type: GraphQLString },
+      keywords: { type: new GraphQLList(GraphQLString) }
+    }
+  });
+
+  const BlogQuery = new GraphQLObjectType({
+    name: "Query",
+    fields: {
+      article: {
+        type: BlogArticle,
+        args: { id: { type: GraphQLID } },
+        resolve: (_, { id }) => article(id)
+      },
+      feed: {
+        type: new GraphQLList(BlogArticle),
+        resolve: () =>
+          Promise.resolve([
+            article(1),
+            article(2),
+            article(3),
+            article(4),
+            article(5),
+            article(6),
+            article(7),
+            article(8),
+            article(9),
+            article(10)
+          ])
+      }
+    }
+  });
+
+  const johnSmith = {
+    id: 123,
+    name: "John Smith",
+    pic: (width: number, height: number) => getPic(123, width, height),
+    recentArticle: null
+  };
+  johnSmith.recentArticle = article(1);
+
+  function article(id: number): any {
+    return {
+      id,
+      isPublished: "true",
+      author: johnSmith,
+      title: "My Article " + id,
+      body: "This is a post",
+      hidden: "This data is not exposed in the schema",
+      keywords: ["foo", "bar", 1, true, null]
+    };
+  }
+  function getPic(uid: number, width: number, height: number) {
+    return {
+      url: `cdn://${uid}`,
+      width: `${width}`,
+      height: `${height}`
+    };
+  }
+
+  return new GraphQLSchema({
+    query: BlogQuery
+  });
+}

--- a/src/__benchmarks__/schema-variables.benchmark.ts
+++ b/src/__benchmarks__/schema-variables.benchmark.ts
@@ -49,10 +49,15 @@ fragment articleFields on Article {
 }
 `);
 
-const { query: compilerParserNoLeaf }: any = compileQuery(schema, document, "", {
-  enableVariableCompilation: true,
-  disableLeafSerialization: true
-});
+const { query: compilerParserNoLeaf }: any = compileQuery(
+  schema,
+  document,
+  "",
+  {
+    enableVariableCompilation: true,
+    disableLeafSerialization: true
+  }
+);
 const compilerParser: any = compileQuery(schema, document, "", {
   enableVariableCompilation: true,
   customSerializers: {
@@ -77,7 +82,7 @@ const { query: defaultParserNoLeaf }: any = compileQuery(schema, document, "", {
   enableVariableCompilation: false,
   disableLeafSerialization: true
 });
-const vars = {id: "1"};
+const vars = { id: "1" };
 
 const suite = new Benchmark.Suite();
 
@@ -85,34 +90,40 @@ suite
   .add("graphql-js", {
     defer: true,
     fn(deferred: any) {
-      const p: any = execute(schema, document, undefined,undefined, vars);
+      const p: any = execute(schema, document, undefined, undefined, vars);
       p.then(() => deferred.resolve());
     }
   })
-    .add("graphql-jit - default", {
-      defer: true,
-      fn(deferred: any) {
-        defaultParser(undefined, undefined, vars).then(() => deferred.resolve());
-      }
-    })
-    .add("graphql-jit - default no leaf", {
-      defer: true,
-      fn(deferred: any) {
-        defaultParserNoLeaf(undefined, undefined, vars).then(() => deferred.resolve());
-      }
-    })
-    .add("graphql-jit - compiled", {
-      defer: true,
-      fn(deferred: any) {
-        compilerParser.query(undefined, undefined, vars).then(() => deferred.resolve());
-      }
-    })
-    .add("graphql-jit - compiled no leaf", {
-      defer: true,
-      fn(deferred: any) {
-        compilerParserNoLeaf(undefined, undefined, vars).then(() => deferred.resolve());
-      }
-    })
+  .add("graphql-jit - default", {
+    defer: true,
+    fn(deferred: any) {
+      defaultParser(undefined, undefined, vars).then(() => deferred.resolve());
+    }
+  })
+  .add("graphql-jit - default no leaf", {
+    defer: true,
+    fn(deferred: any) {
+      defaultParserNoLeaf(undefined, undefined, vars).then(() =>
+        deferred.resolve()
+      );
+    }
+  })
+  .add("graphql-jit - compiled", {
+    defer: true,
+    fn(deferred: any) {
+      compilerParser
+        .query(undefined, undefined, vars)
+        .then(() => deferred.resolve());
+    }
+  })
+  .add("graphql-jit - compiled no leaf", {
+    defer: true,
+    fn(deferred: any) {
+      compilerParserNoLeaf(undefined, undefined, vars).then(() =>
+        deferred.resolve()
+      );
+    }
+  })
   // add listeners
   .on("cycle", (event: any) => {
     // tslint:disable-next-line

--- a/src/__tests__/inspect.test.ts
+++ b/src/__tests__/inspect.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import inspect, { nodejsCustomInspectSymbol } from "../inspect";
+
+describe("inspect", () => {
+  it("undefined", () => {
+    expect(inspect(undefined)).toEqual("undefined");
+  });
+
+  it("null", () => {
+    expect(inspect(null)).toEqual("null");
+  });
+
+  it("boolean", () => {
+    expect(inspect(true)).toEqual("true");
+    expect(inspect(false)).toEqual("false");
+  });
+
+  it("string", () => {
+    expect(inspect("")).toEqual('""');
+    expect(inspect("abc")).toEqual('"abc"');
+    // $FlowFixMe
+    expect(inspect('"')).toEqual(String.raw`"\""`);
+  });
+
+  it("number", () => {
+    expect(inspect(0.0)).toEqual("0");
+    expect(inspect(3.14)).toEqual("3.14");
+    expect(inspect(NaN)).toEqual("NaN");
+    expect(inspect(Infinity)).toEqual("Infinity");
+    expect(inspect(-Infinity)).toEqual("-Infinity");
+  });
+
+  it("function", () => {
+    expect(inspect(() => 0)).toEqual("[function]");
+
+    function testFunc() {}
+    expect(inspect(testFunc)).toEqual("[function testFunc]");
+  });
+
+  it("array", () => {
+    expect(inspect([])).toEqual("[]");
+    expect(inspect([null])).toEqual("[null]");
+    expect(inspect([1, NaN])).toEqual("[1, NaN]");
+    expect(inspect([["a", "b"], "c"])).toEqual('[["a", "b"], "c"]');
+
+    expect(inspect([[[]]])).toEqual("[[[]]]");
+    expect(inspect([[["a"]]])).toEqual("[[[Array]]]");
+
+    expect(inspect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])).toEqual(
+      "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"
+    );
+
+    expect(inspect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).toEqual(
+      "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ... 1 more item]"
+    );
+
+    expect(inspect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])).toEqual(
+      "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ... 2 more items]"
+    );
+  });
+
+  it("object", () => {
+    expect(inspect({})).toEqual("{}");
+    expect(inspect({ a: 1 })).toEqual("{ a: 1 }");
+    expect(inspect({ a: 1, b: 2 })).toEqual("{ a: 1, b: 2 }");
+    expect(inspect({ array: [null, 0] })).toEqual("{ array: [null, 0] }");
+
+    expect(inspect({ a: { b: {} } })).toEqual("{ a: { b: {} } }");
+    expect(inspect({ a: { b: { c: 1 } } })).toEqual("{ a: { b: [Object] } }");
+
+    const map = Object.create(null);
+    map["a"] = true;
+    map["b"] = null;
+    expect(inspect(map)).toEqual("{ a: true, b: null }");
+  });
+
+  it("custom inspect", () => {
+    const object = {
+      inspect() {
+        return "<custom inspect>";
+      }
+    };
+
+    expect(inspect(object)).toEqual("<custom inspect>");
+  });
+
+  it("custom inspect that return `this` should work", () => {
+    const object = {
+      inspect() {
+        return this;
+      }
+    };
+
+    expect(inspect(object)).toEqual("{ inspect: [function inspect] }");
+  });
+
+  it("custom symbol inspect is take precedence", () => {
+    const object = {
+      inspect() {
+        return "<custom inspect>";
+      },
+      [String(nodejsCustomInspectSymbol)]() {
+        return "<custom symbol inspect>";
+      }
+    };
+
+    expect(inspect(object)).toEqual("<custom symbol inspect>");
+  });
+
+  it("custom inspect returning object values", () => {
+    const object = {
+      inspect() {
+        return { custom: "inspect" };
+      }
+    };
+
+    expect(inspect(object)).toEqual('{ custom: "inspect" }');
+  });
+
+  it("custom inspect function that uses this", () => {
+    const object = {
+      str: "Hello World!",
+      inspect() {
+        return this.str;
+      }
+    };
+
+    expect(inspect(object)).toEqual("Hello World!");
+  });
+
+  it("detect circular objects", () => {
+    const obj: any = {};
+    obj.self = obj;
+    obj.deepSelf = { self: obj };
+
+    expect(inspect(obj)).toEqual(
+      "{ self: [Circular], deepSelf: { self: [Circular] } }"
+    );
+
+    const array: any = [];
+    array[0] = array;
+    array[1] = [array];
+
+    expect(inspect(array)).toEqual("[[Circular], [[Circular]]]");
+
+    const mixed: any = { array: [] };
+    mixed.array[0] = mixed;
+
+    expect(inspect(mixed)).toEqual("{ array: [[Circular]] }");
+
+    const customA = {
+      inspect: () => customB
+    };
+
+    const customB = {
+      inspect: () => customA
+    };
+
+    expect(inspect(customA)).toEqual("[Circular]");
+  });
+
+  it("Use class names for the shortform of an object", () => {
+    class Foo {
+      foo: string;
+
+      constructor() {
+        this.foo = "bar";
+      }
+    }
+
+    expect(inspect([[new Foo()]])).toEqual("[[[Foo]]]");
+
+    (Foo.prototype as any)[Symbol.toStringTag] = "Bar";
+    expect(inspect([[new Foo()]])).toEqual("[[[Bar]]]");
+  });
+});

--- a/src/__tests__/inspect.test.ts
+++ b/src/__tests__/inspect.test.ts
@@ -1,10 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow strict
+ * Based on https://github.com/graphql/graphql-js/blob/master/src/jsutils/__tests__/inspect-test.js
  */
 
 import inspect, { nodejsCustomInspectSymbol } from "../inspect";
@@ -52,7 +47,7 @@ describe("inspect", () => {
     expect(inspect([["a", "b"], "c"])).toEqual('[["a", "b"], "c"]');
 
     expect(inspect([[[]]])).toEqual("[[[]]]");
-    expect(inspect([[["a"]]])).toEqual("[[[Array]]]");
+    expect(inspect([[[["a"]]]])).toEqual("[[[[Array]]]]");
 
     expect(inspect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])).toEqual(
       "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]"
@@ -74,7 +69,9 @@ describe("inspect", () => {
     expect(inspect({ array: [null, 0] })).toEqual("{ array: [null, 0] }");
 
     expect(inspect({ a: { b: {} } })).toEqual("{ a: { b: {} } }");
-    expect(inspect({ a: { b: { c: 1 } } })).toEqual("{ a: { b: [Object] } }");
+    expect(inspect({ a: { b: { c: { d: 1 } } } })).toEqual(
+      "{ a: { b: { c: [Object] } } }"
+    );
 
     const map = Object.create(null);
     map["a"] = true;
@@ -176,9 +173,9 @@ describe("inspect", () => {
       }
     }
 
-    expect(inspect([[new Foo()]])).toEqual("[[[Foo]]]");
+    expect(inspect([[[new Foo()]]])).toEqual("[[[[Foo]]]]");
 
     (Foo.prototype as any)[Symbol.toStringTag] = "Bar";
-    expect(inspect([[new Foo()]])).toEqual("[[[Bar]]]");
+    expect(inspect([[[new Foo()]]])).toEqual("[[[[Bar]]]]");
   });
 });

--- a/src/__tests__/variables.test.ts
+++ b/src/__tests__/variables.test.ts
@@ -150,9 +150,7 @@ const schema = new GraphQLSchema({ query: TestType });
 
 function executeQuery(query: string, variableValues?: any) {
   const document = parse(query);
-  const prepared: any = compileQuery(schema, document, "", {
-    enableVariableCompilation: true
-  });
+  const prepared: any = compileQuery(schema, document, "");
   if (prepared.errors) {
     return prepared;
   }
@@ -736,13 +734,15 @@ describe("Execute: Handles inputs", () => {
       });
     });
 
-
     test("does not allow 64bit integers to be set", async () => {
-      const result = await executeQuery(`
+      const result = await executeQuery(
+        `
          query ($int: Int) {
           fieldWithNullableIntInput(input: $int)
         }
-      `, {int: Number.MAX_SAFE_INTEGER + 1});
+      `,
+        { int: Number.MAX_SAFE_INTEGER + 1 }
+      );
 
       expect(result).toEqual({
         errors: [
@@ -753,12 +753,12 @@ describe("Execute: Handles inputs", () => {
                 line: 2
               }
             ],
-            message: "Variable \"$int\" got invalid value 9007199254740992; Expected type Int; Int cannot represent non 32-bit signed integer value: 9007199254740992"
+            message:
+              'Variable "$int" got invalid value 9007199254740992; Expected type Int; Int cannot represent non 32-bit signed integer value: 9007199254740992'
           }
         ]
       });
     });
-
 
     test("does not bad inputs to be set to a value in a variable", async () => {
       const result = await executeQuery(doc, {

--- a/src/__tests__/variables.test.ts
+++ b/src/__tests__/variables.test.ts
@@ -377,7 +377,7 @@ describe("Execute: Handles inputs", () => {
             {
               message:
                 "Variable \"$input\" got invalid value { a: \"foo\", b: \"bar\", c: null }; " +
-                "Expected non-nullable type String! not to be null at input.c.",
+                "Expected non-nullable type String! not to be null at value.c.",
               locations: [{ line: 2, column: 16 }]
             }
           ]
@@ -409,7 +409,7 @@ describe("Execute: Handles inputs", () => {
             {
               message:
                 "Variable \"$input\" got invalid value { a: \"foo\", b: \"bar\" }; " +
-                "Field input.c of required type String! was not provided.",
+                "Field value.c of required type String! was not provided.",
               locations: [{ line: 2, column: 16 }]
             }
           ]
@@ -815,7 +815,7 @@ describe("Execute: Handles inputs", () => {
           {
             message:
               "Variable \"$input\" got invalid value [\"A\", null, \"B\"]; " +
-              "Expected non-nullable type String! not to be null at input[1].",
+              "Expected non-nullable type String! not to be null at value[1].",
             locations: [{ line: 2, column: 16 }]
           }
         ]
@@ -865,7 +865,7 @@ describe("Execute: Handles inputs", () => {
           {
             message:
               "Variable \"$input\" got invalid value [\"A\", null, \"B\"]; " +
-              "Expected non-nullable type String! not to be null at input[1].",
+              "Expected non-nullable type String! not to be null at value[1].",
             locations: [{ line: 2, column: 16 }]
           }
         ]

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -431,11 +431,8 @@ export function getVariableValues(
 
 export function computeLocations(
   nodes: ASTNode[]
-): SourceLocation[] | undefined {
-  if (!Array.isArray(nodes) || !nodes.length) {
-    return undefined;
-  }
-  const locations = nodes.reduce(
+): SourceLocation[] {
+  return nodes.reduce(
     (list, node) => {
       if (node.loc) {
         list.push(getLocation(node.loc.source, node.loc.start));
@@ -444,12 +441,7 @@ export function computeLocations(
     },
     [] as SourceLocation[]
   );
-  if (locations.length === 0) {
-    return undefined;
-  }
-  return locations;
 }
-
 
 export interface ObjectPath {
   prev: ObjectPath | undefined;
@@ -463,7 +455,6 @@ export interface ObjectPath {
 // the function name
 type ResponsePathType = "variable" | "literal" | "meta";
 
-
 export function addPath(
     responsePath: ObjectPath | undefined,
     key: string,
@@ -471,7 +462,6 @@ export function addPath(
 ): ObjectPath {
   return { prev: responsePath, key, type };
 }
-
 
 function hasOwnProperty(obj: any, prop: string): boolean {
   return Object.prototype.hasOwnProperty.call(obj, prop);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,4 +1,5 @@
 import {
+  ASTNode,
   coerceValue,
   DirectiveNode,
   FieldNode,
@@ -28,7 +29,7 @@ import { CoercedVariableValues } from "graphql/execution/values";
 import { Kind } from "graphql/language";
 import Maybe from "graphql/tsutils/Maybe";
 import { isAbstractType } from "graphql/type";
-import { inspect } from "util";
+import inspect from "./inspect";
 
 /**
  * Given a selectionSet, adds all of the fields in that selection to
@@ -429,7 +430,7 @@ export function getVariableValues(
 }
 
 export function computeLocations(
-  nodes: FieldNode[]
+  nodes: ASTNode[]
 ): SourceLocation[] | undefined {
   if (!Array.isArray(nodes) || !nodes.length) {
     return undefined;
@@ -448,6 +449,29 @@ export function computeLocations(
   }
   return locations;
 }
+
+
+export interface ObjectPath {
+  prev: ObjectPath | undefined;
+  key: string;
+  type: ResponsePathType;
+}
+
+// response path is used for identifying
+// the info resolver function as well as the path in errros,
+// the meta type is used for elements that are only to be used for
+// the function name
+type ResponsePathType = "variable" | "literal" | "meta";
+
+
+export function addPath(
+    responsePath: ObjectPath | undefined,
+    key: string,
+    type: ResponsePathType = "literal"
+): ObjectPath {
+  return { prev: responsePath, key, type };
+}
+
 
 function hasOwnProperty(obj: any, prop: string): boolean {
   return Object.prototype.hasOwnProperty.call(obj, prop);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,6 +1,5 @@
 import {
   ASTNode,
-  coerceValue,
   DirectiveNode,
   FieldNode,
   FragmentDefinitionNode,
@@ -12,24 +11,19 @@ import {
   GraphQLField,
   GraphQLIncludeDirective,
   GraphQLObjectType,
-  GraphQLSchema,
   GraphQLSkipDirective,
   InlineFragmentNode,
-  isInputType,
   isNonNullType,
   print,
   SelectionSetNode,
   SourceLocation,
   typeFromAST,
   valueFromAST,
-  VariableDefinitionNode
 } from "graphql";
 import { ExecutionContext, getFieldDef } from "graphql/execution/execute";
-import { CoercedVariableValues } from "graphql/execution/values";
 import { Kind } from "graphql/language";
 import Maybe from "graphql/tsutils/Maybe";
 import { isAbstractType } from "graphql/type";
-import inspect from "./inspect";
 
 /**
  * Given a selectionSet, adds all of the fields in that selection to
@@ -353,82 +347,6 @@ function keyMap<T>(
   );
 }
 
-/**
- * Prepares an object map of variableValues of the correct type based on the
- * provided variable definitions and arbitrary input. If the input cannot be
- * parsed to match the variable definitions, a GraphQLError will be thrown.
- */
-export function getVariableValues(
-  schema: GraphQLSchema,
-  varDefNodes: ReadonlyArray<VariableDefinitionNode>,
-  inputs: { [key: string]: any }
-): CoercedVariableValues {
-  const errors = [];
-  const coercedValues: { [key: string]: any } = Object.create(null);
-  for (const varDefNode of varDefNodes) {
-    const varName = varDefNode.variable.name.value;
-    const varType = typeFromAST(schema, varDefNode.type as any);
-    if (!varType || !isInputType(varType)) {
-      // Must use input types for variables. This should be caught during
-      // validation, however is checked again here for safety.
-      errors.push(
-        new GraphQLError(
-          `Variable "$${varName}" expected value of type ` +
-            `"${
-              varType ? varType : print(varDefNode.type)
-            }" which cannot be used as an input type.`,
-          [varDefNode.type]
-        )
-      );
-    } else {
-      const hasValue = hasOwnProperty(inputs, varName);
-      const value = hasValue ? inputs[varName] : undefined;
-      if (!hasValue && varDefNode.defaultValue) {
-        // If no value was provided to a variable with a default value,
-        // use the default value.
-        coercedValues[varName] = valueFromAST(varDefNode.defaultValue, varType);
-      } else if ((!hasValue || value === null) && isNonNullType(varType)) {
-        // If no value or a nullish value was provided to a variable with a
-        // non-null type (required), produce an error.
-        errors.push(
-          new GraphQLError(
-            hasValue
-              ? `Variable "$${varName}" of non-null type ` +
-                `"${varType}" must not be null.`
-              : `Variable "$${varName}" of required type ` +
-                `"${varType}" was not provided.`,
-            [varDefNode]
-          )
-        );
-      } else if (hasValue) {
-        if (value === null) {
-          // If the explicit value `null` was provided, an entry in the coerced
-          // values must exist as the value `null`.
-          coercedValues[varName] = null;
-        } else {
-          // Otherwise, a non-null value was provided, coerce it to the expected
-          // type or report an error if coercion fails.
-          const coerced = coerceValue(value, varType, varDefNode);
-          const coercionErrors = coerced.errors;
-          if (coercionErrors) {
-            coercionErrors.forEach((error: Error) => {
-              error.message =
-                `Variable "$${varName}" got invalid ` +
-                `value ${inspect(value)}; ${error.message}`;
-            });
-            errors.push(...coercionErrors);
-          } else {
-            coercedValues[varName] = coerced.value;
-          }
-        }
-      }
-    }
-  }
-  return errors.length === 0
-    ? { errors: undefined, coerced: coercedValues }
-    : { errors, coerced: undefined };
-}
-
 export function computeLocations(
   nodes: ASTNode[]
 ): SourceLocation[] {
@@ -461,8 +379,4 @@ export function addPath(
     type: ResponsePathType = "literal"
 ): ObjectPath {
   return { prev: responsePath, key, type };
-}
-
-function hasOwnProperty(obj: any, prop: string): boolean {
-  return Object.prototype.hasOwnProperty.call(obj, prop);
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,10 +1,5 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @flow strict
+ * Based on https://github.com/graphql/graphql-js/blob/master/src/error/GraphQLError.js
  */
 
 import {GraphQLError as UpstreamGraphQLError, printError, SourceLocation} from "graphql";

--- a/src/error.ts
+++ b/src/error.ts
@@ -23,7 +23,7 @@ export function GraphQLError(
             },
             locations: {
                 value: locations || undefined,
-                enumerable: Boolean(locations),
+                enumerable: locations && locations.length > 0,
             },
             path: {
                 value: path || undefined,

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -29,23 +29,23 @@ import {
     collectFields,
     ExecutionContext,
 } from "graphql/execution/execute";
+import {CoercedVariableValues} from "graphql/execution/values";
 import { FieldNode, OperationDefinitionNode } from "graphql/language/ast";
 import Maybe from "graphql/tsutils/Maybe";
 import { GraphQLTypeResolver } from "graphql/type/definition";
 import {
+    addPath,
     Arguments,
     collectSubfields,
     computeLocations,
     getArgumentDefs,
     getVariableValues,
-    resolveFieldDef,
     ObjectPath,
-    addPath
+    resolveFieldDef
 } from "./ast";
 import {GraphQLError as CustomGraphQLError} from "./error";
 import { queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
-import {CoercedVariableValues} from "graphql/execution/values";
 import {compileVariableParsing} from "./variables";
 
 export interface CompilerOptions {
@@ -161,8 +161,9 @@ export function compileQuery(
             stringify = JSON.stringify;
         }
         const getVariables = options.enableVariableCompilation ?
-            compileVariableParsing(schema, context.operation.variableDefinitions || []):
-            (inputs: { [key: string]: any }) => getVariableValues(schema, context.operation.variableDefinitions || [], inputs);
+            compileVariableParsing(schema, context.operation.variableDefinitions || []) :
+            (inputs: { [key: string]: any }) => getVariableValues(schema,
+                context.operation.variableDefinitions || [], inputs);
 
         const mainBody = compileOperation(context);
         const functionBody = `
@@ -1227,7 +1228,7 @@ function getErrorObject(
     if (!originalError) {
         return `{
         message: ${message},
-        locations: ${locations ? JSON.stringify(locations) : "undefined"},
+        locations: ${JSON.stringify(locations)},
         path: ${serializeResponsePathAsArray(path)},
       }`;
     }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -39,7 +39,6 @@ import {
     collectSubfields,
     computeLocations,
     getArgumentDefs,
-    getVariableValues,
     ObjectPath,
     resolveFieldDef
 } from "./ast";
@@ -55,8 +54,6 @@ export interface CompilerOptions {
     // which is responsible for coercion,
     // only safe for use if the output is completely correct.
     disableLeafSerialization: boolean;
-
-    enableVariableCompilation: boolean;
 
     // Map of serializers to override
     // the key should be the name passed to the Scalar or Enum type
@@ -139,7 +136,6 @@ export function compileQuery(
         const options = {
             customJSONSerializer: false,
             disableLeafSerialization: false,
-            enableVariableCompilation: false,
             customSerializers: {},
             ...partialOptions
         };
@@ -160,10 +156,7 @@ export function compileQuery(
         } else {
             stringify = JSON.stringify;
         }
-        const getVariables = options.enableVariableCompilation ?
-            compileVariableParsing(schema, context.operation.variableDefinitions || []) :
-            (inputs: { [key: string]: any }) => getVariableValues(schema,
-                context.operation.variableDefinitions || [], inputs);
+        const getVariables = compileVariableParsing(schema, context.operation.variableDefinitions || []);
 
         const mainBody = compileOperation(context);
         const functionBody = `

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1220,7 +1220,7 @@ function getErrorObject(
     return `new GraphQLError(${message},
     ${JSON.stringify(computeLocations(nodes))},
       ${serializeResponsePathAsArray(path)},
-      ${originalError ? originalError: "undefined"})`;
+      ${originalError ? originalError : "undefined"})`;
 }
 
 function getResolverName(parentName: string, name: string) {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1217,19 +1217,10 @@ function getErrorObject(
     message: string,
     originalError?: string
 ): string {
-    const locations = computeLocations(nodes);
-    if (!originalError) {
-        return `{
-        message: ${message},
-        locations: ${JSON.stringify(locations)},
-        path: ${serializeResponsePathAsArray(path)},
-      }`;
-    }
-
     return `new GraphQLError(${message},
-    ${locations ? JSON.stringify(locations) : "undefined"},
+    ${JSON.stringify(computeLocations(nodes))},
       ${serializeResponsePathAsArray(path)},
-      ${originalError})`;
+      ${originalError ? originalError: "undefined"})`;
 }
 
 function getResolverName(parentName: string, name: string) {

--- a/src/inspect.ts
+++ b/src/inspect.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const nodejsCustomInspectSymbol = Symbol.for('nodejs.util.inspect.custom');
+
+/**
+ * Used to print values in error messages.
+ */
+export default function inspect(value: any): string {
+    switch (typeof value) {
+        case 'string':
+            return JSON.stringify(value);
+        case 'function':
+            return value.name ? `[function ${value.name}]` : '[function]';
+        case 'object':
+            if (value) {
+                const customInspectFn = getCustomFn(value);
+
+                if (customInspectFn) {
+                    const customValue = customInspectFn.call(value);
+                    return typeof customValue === 'string'
+                        ? customValue
+                        : inspect(customValue);
+                } else if (Array.isArray(value)) {
+                    return '[' + value.map(inspect).join(', ') + ']';
+                }
+
+                const properties = Object.keys(value)
+                    .map(k => `${k}: ${inspect(value[k])}`)
+                    .join(', ');
+                return properties ? '{ ' + properties + ' }' : '{}';
+            }
+            return String(value);
+        default:
+            return String(value);
+    }
+}
+
+function getCustomFn(object: any) {
+    const customInspectFn = object[String(nodejsCustomInspectSymbol)];
+
+    if (typeof customInspectFn === 'function') {
+        return customInspectFn;
+    }
+
+    if (typeof object.inspect === 'function') {
+        return object.inspect;
+    }
+}

--- a/src/inspect.ts
+++ b/src/inspect.ts
@@ -1,15 +1,11 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
+ * Based on https://github.com/graphql/graphql-js/blob/master/src/jsutils/inspect.js
  */
 
 export const nodejsCustomInspectSymbol = Symbol.for("nodejs.util.inspect.custom");
 
 const MAX_ARRAY_LENGTH = 10;
-const MAX_RECURSIVE_DEPTH = 2;
+const MAX_RECURSIVE_DEPTH = 3;
 
 /**
  * Used to print values in error messages.

--- a/src/inspect.ts
+++ b/src/inspect.ts
@@ -6,49 +6,128 @@
  *
  */
 
-const nodejsCustomInspectSymbol = Symbol.for('nodejs.util.inspect.custom');
+export const nodejsCustomInspectSymbol = Symbol.for("nodejs.util.inspect.custom");
+
+const MAX_ARRAY_LENGTH = 10;
+const MAX_RECURSIVE_DEPTH = 2;
 
 /**
  * Used to print values in error messages.
  */
 export default function inspect(value: any): string {
+    return formatValue(value, []);
+}
+
+function formatValue(value: any, seenValues: any[]) {
     switch (typeof value) {
-        case 'string':
+        case "string":
             return JSON.stringify(value);
-        case 'function':
-            return value.name ? `[function ${value.name}]` : '[function]';
-        case 'object':
-            if (value) {
-                const customInspectFn = getCustomFn(value);
-
-                if (customInspectFn) {
-                    const customValue = customInspectFn.call(value);
-                    return typeof customValue === 'string'
-                        ? customValue
-                        : inspect(customValue);
-                } else if (Array.isArray(value)) {
-                    return '[' + value.map(inspect).join(', ') + ']';
-                }
-
-                const properties = Object.keys(value)
-                    .map(k => `${k}: ${inspect(value[k])}`)
-                    .join(', ');
-                return properties ? '{ ' + properties + ' }' : '{}';
-            }
-            return String(value);
+        case "function":
+            return value.name ? `[function ${value.name}]` : "[function]";
+        case "object":
+            return formatObjectValue(value, seenValues);
         default:
             return String(value);
     }
 }
 
+function formatObjectValue(value: any, previouslySeenValues: any[]): string {
+    if (previouslySeenValues.indexOf(value) !== -1) {
+        return "[Circular]";
+    }
+    const seenValues = [...previouslySeenValues, value];
+
+    if (value) {
+        const customInspectFn = getCustomFn(value);
+
+        if (customInspectFn) {
+            // $FlowFixMe(>=0.90.0)
+            const customValue = customInspectFn.call(value);
+
+            // check for infinite recursion
+            if (customValue !== value) {
+                return typeof customValue === "string"
+                    ? customValue
+                    : formatValue(customValue, seenValues);
+            }
+        } else if (Array.isArray(value)) {
+            return formatArray(value, seenValues);
+        }
+
+        return formatObject(value, seenValues);
+    }
+
+    return String(value);
+}
+
+function formatObject(object: {[key: string]: string}, seenValues: any[]): string {
+    const keys = Object.keys(object);
+    if (keys.length === 0) {
+        return "{}";
+    }
+
+    if (seenValues.length > MAX_RECURSIVE_DEPTH) {
+        return "[" + getObjectTag(object) + "]";
+    }
+
+    const properties = keys.map(key => {
+        const value = formatValue(object[key], seenValues);
+        return key + ": " + value;
+    });
+
+    return "{ " + properties.join(", ") + " }";
+}
+
+function formatArray(array: any[], seenValues: any[]) {
+    if (array.length === 0) {
+        return "[]";
+    }
+
+    if (seenValues.length > MAX_RECURSIVE_DEPTH) {
+        return "[Array]";
+    }
+
+    const len = Math.min(MAX_ARRAY_LENGTH, array.length);
+    const remaining = array.length - len;
+    const items = [];
+
+    for (let i = 0; i < len; ++i) {
+        items.push(formatValue(array[i], seenValues));
+    }
+
+    if (remaining === 1) {
+        items.push("... 1 more item");
+    } else if (remaining > 1) {
+        items.push(`... ${remaining} more items`);
+    }
+
+    return "[" + items.join(", ") + "]";
+}
+
 function getCustomFn(object: any) {
     const customInspectFn = object[String(nodejsCustomInspectSymbol)];
 
-    if (typeof customInspectFn === 'function') {
+    if (typeof customInspectFn === "function") {
         return customInspectFn;
     }
 
-    if (typeof object.inspect === 'function') {
+    if (typeof object.inspect === "function") {
         return object.inspect;
     }
+}
+
+function getObjectTag(object: any) {
+    const tag = Object.prototype.toString
+        .call(object)
+        .replace(/^\[object /, "")
+        .replace(/]$/, "");
+
+    if (tag === "Object" && typeof object.constructor === "function") {
+        const name = object.constructor.name;
+        if (typeof name === "string") {
+            return name;
+        }
+    }
+
+    return tag;
 }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,0 +1,291 @@
+import {
+    GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInputType, GraphQLInt,
+    GraphQLSchema, GraphQLString, isEnumType,
+    isInputType, isListType,
+    isNonNullType, isScalarType, print, SourceLocation,
+    typeFromAST,
+    valueFromAST,
+    VariableDefinitionNode
+} from "graphql";
+import {CoercedVariableValues} from "graphql/execution/values";
+import {GraphQLError} from "./error";
+import {addPath, computeLocations, ObjectPath} from "./ast";
+import inspect from "./inspect";
+
+interface CompilationContext {
+    inputPath: ObjectPath;
+    responsePath: ObjectPath;
+    depth: number;
+    varDefNode: VariableDefinitionNode;
+    dependencies: Map<string, (...args: any[]) => any>;
+    errorMessage?: string;
+}
+
+function createSubCompilationContext(
+    context: CompilationContext
+): CompilationContext {
+    return { ...context};
+}
+export function compileVariableParsing(
+    schema: GraphQLSchema,
+    varDefNodes: ReadonlyArray<VariableDefinitionNode>
+): (inputs: { [key: string]: any }) => CoercedVariableValues {
+    const errors = [];
+    const coercedValues: { [key: string]: any } = Object.create(null);
+    let body = `
+    return function getVariables (input) {
+    const errors = [];
+    `;
+    const dependencies = new Map();
+    for (const varDefNode of varDefNodes) {
+        const context: CompilationContext = {
+            varDefNode,
+            depth: 0,
+            inputPath: addPath(undefined, "input"),
+            responsePath: addPath(undefined, "coerced"),
+            dependencies
+        };
+        const varName = varDefNode.variable.name.value;
+        let varType = typeFromAST(schema, varDefNode.type as any);
+        if (!varType || !isInputType(varType)) {
+            // Must use input types for variables. This should be caught during
+            // validation, however is checked again here for safety.
+            errors.push(
+                new (GraphQLError as any)(
+                    `Variable "$${varName}" expected value of type ` +
+                    `"${
+                        varType ? varType : print(varDefNode.type)
+                        }" which cannot be used as an input type.`,
+                    computeLocations([varDefNode.type])
+                )
+            );
+            continue;
+        }
+        if (varDefNode.defaultValue) {
+            // If no value was provided to a variable with a default value,
+            // use the default value.
+            coercedValues[varName] = valueFromAST(varDefNode.defaultValue, varType);
+        }
+
+        const hasValueName = hasValue(addPath(context.inputPath, varName));
+        body += `const ${hasValueName} = Object.prototype.hasOwnProperty.call(${getObjectPath(context.inputPath)}, "${varName}");\n`;
+        context.inputPath = addPath(context.inputPath, varName);
+        context.responsePath = addPath(context.responsePath, varName);
+        body += generateInput(context, varType, varName, hasValueName, false);
+    }
+
+    if (errors.length > 0) {
+        throw errors;
+    }
+
+    body += "if (errors.length > 0) {return {errors, coerced: undefined};}";
+    body += "return {errors: undefined, coerced};\n}";
+    // console.log(body);
+    return Function
+        .apply(null, ["coerced", "GraphQLError", "inspect"].concat(Array.from(dependencies.keys())).concat(body))
+        .apply(null, [coercedValues, GraphQLError, inspect].concat(Array.from(dependencies.values())));
+}
+
+function generateInput(context: CompilationContext, varType: GraphQLInputType, varName: string, hasValueName: string, wrapInList: boolean) {
+    const currentOutput = getObjectPath(context.responsePath);
+    const currentInput = getObjectPath(context.inputPath);
+    const errorLocation = printErrorLocation(computeLocations([context.varDefNode]));
+
+    let body = `if (${currentInput} == null) {\n`;
+
+    if (isNonNullType(varType)) {
+        let nonNullMessage;
+        let omittedMessage;
+        if (context.errorMessage) {
+            const objectPath = printObjectPath(context.responsePath);
+            nonNullMessage = `${context.errorMessage} + \`Expected non-nullable type ${varType} not to be null at ${objectPath}.\``;
+            omittedMessage = `${context.errorMessage} + \`Field ${objectPath} of required type ${varType} was not provided.\``;
+        } else {
+            nonNullMessage = `'Variable "$${varName}" of non-null type "${varType}" must not be null.'`;
+            omittedMessage = `'Variable "$${varName}" of required type "${varType}" was not provided.'`;
+        }
+        varType = varType.ofType;
+        body += `
+        if (${currentOutput} == null) {
+            errors.push(new GraphQLError(${hasValueName} ? ${nonNullMessage} : ${omittedMessage}, ${errorLocation}));
+        }
+        `;
+    } else {
+        body += `if (${hasValueName}) { ${currentOutput} = null; }\n`;
+    }
+    body += "} else {";
+    if (isScalarType(varType)) {
+        switch (varType.name) {
+            case GraphQLID.name:
+            case GraphQLString.name:
+                body += `
+                    if (typeof ${currentInput} === "string") {
+                        ${currentOutput} = ${currentInput};
+                    } else {
+                        errors.push(new GraphQLError('Variable "$${varName}" got invalid value '
+                        + inspect(${currentInput}) + "; " + 
+                        'Expected type ${varType.name}; ${varType.name} cannot represent a non string value: ' + inspect(${currentInput}), ${errorLocation}));
+                    }
+                    `;
+                break;
+            case GraphQLBoolean.name:
+                body += `
+                    if (typeof ${currentInput} === "boolean") {
+                        ${currentOutput} = ${currentInput};
+                    } else {
+                        errors.push(new GraphQLError('Variable "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
+                    }
+                    `;
+                break;
+            case GraphQLInt.name:
+                // TODO validate 32 bit
+                body += `
+                    if (Number.isInteger(${currentInput})) {
+                        ${currentOutput} = ${currentInput};
+                    } else {
+                        errors.push(new GraphQLError('Variable "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
+                    }
+                    `;
+                break;
+            case GraphQLFloat.name:
+                body += `
+                    if (Number.isFinite(${currentInput})) {
+                        ${currentOutput} = ${currentInput};
+                    } else {
+                        errors.push(new GraphQLError('Variable "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
+                    }
+                    `;
+                break;
+            default:
+                context.dependencies.set(`${varType.name}parseValue`, varType.parseValue);
+                body += `
+                    try {
+                      const parseResult = ${varType.name}parseValue(${currentInput});
+                      if (parseResult === undefined || parseResult !== parseResult) {
+                        errors.push(new GraphQLError('Expected type "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
+                      }
+                      ${currentOutput} = parseResult;
+                    } catch (error) {
+                      errors.push(new GraphQLError('Expected type "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
+                    }
+                    `;
+        }
+    } else if (isEnumType(varType)) {
+        context.dependencies.set(`${varType.name}getValue`, varType.getValue);
+        body += `
+            if (typeof ${currentInput} === "string") { 
+                const enumValue = ${varType.name}getValue(value);
+              if (enumValue) {
+                ${currentOutput} = enumValue.value;
+              } else {
+                errors.push(new GraphQLError('Variable "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
+            }
+            } else {
+                errors.push(new GraphQLError('Variable "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
+            }
+            `;
+    } else if (isListType(varType)) {
+        context.errorMessage =`'Variable "$${printObjectPath(context.inputPath)}" got invalid value ' + inspect(${currentInput}) + '; '`;
+        const hasValueName = hasValue(context.inputPath);
+        const index = `idx${context.depth}`;
+
+        const subContext = createSubCompilationContext(context);
+        subContext.responsePath = addPath(subContext.responsePath, index, "variable");
+        subContext.inputPath = addPath(subContext.inputPath, index, "variable");
+        subContext.depth++;
+        body += `
+            if (Array.isArray(${currentInput})) {
+                ${currentOutput} = [];
+                for (let ${index} = 0; ${index} < ${currentInput}.length; ++${index}) {
+                    const ${hasValueName} = ${getObjectPath(subContext.inputPath)} !== undefined;
+                    ${generateInput(subContext, varType.ofType, varName, hasValueName, false)}
+                }
+            } else {
+                ${generateInput(context, varType.ofType, varName, hasValueName, true)}
+            }
+`;
+    } else if (isInputType(varType)) {
+        body += `
+            if (typeof ${currentInput} !== 'object') {
+                errors.push(new GraphQLError('Variable "$${varName}" got invalid value '
+                 + inspect(${currentInput}) + "; " + 
+                 'Expected type ${varType.name} to be an object.', ${errorLocation}));
+            } else {
+                ${currentOutput} = {};\n`;
+        const fields = varType.getFields();
+        const allowedFields = [];
+        for (const field of Object.values(fields)) {
+            const subContext = createSubCompilationContext(context);
+            allowedFields.push(field.name);
+            const hasValueName = hasValue(addPath(subContext.inputPath, field.name));
+            body += `const ${hasValueName} = Object.prototype.hasOwnProperty.call(${getObjectPath(subContext.inputPath)}, "${field.name}");\n`;
+            subContext.inputPath = addPath(subContext.inputPath, field.name);
+            subContext.responsePath = addPath(subContext.responsePath, field.name);
+            subContext.errorMessage =`'Variable "$${printObjectPath(context.inputPath)}" got invalid value ' + inspect(${currentInput}) + '; '`;
+            body += generateInput(subContext, field.type, field.name, hasValueName,false);
+        }
+
+        body += `
+            const allowedFields = ${JSON.stringify(allowedFields)};
+            for ( const fieldName of Object.keys(${currentInput})) {
+                if (!allowedFields.includes(fieldName)) {
+                    errors.push(new GraphQLError('Variable "$${varName}" got invalid value '
+                                                 + inspect(${currentInput}) + "; " + 
+                                                 'Field "' + fieldName + '" is not defined by type ${varType.name}.', ${errorLocation}));
+                    break;
+                }
+            }
+        }\n`;
+    }
+    if (wrapInList) {
+        body += `${currentOutput} = [${currentOutput}];\n`;
+    }
+    body += "}\n";
+    return body;
+}
+
+
+function hasValue(path: ObjectPath) {
+    const flattened = [];
+    let curr: ObjectPath | undefined = path;
+    while (curr) {
+        flattened.push(curr.key);
+        curr = curr.prev;
+    }
+    return `hasValue${flattened.join("_")}`;
+}
+
+
+function printErrorLocation(location: SourceLocation[] | undefined) {
+    return location ? JSON.stringify(location): undefined;
+}
+
+function getObjectPath(path: ObjectPath): string {
+    const flattened = [];
+    let curr: ObjectPath | undefined = path;
+    while (curr) {
+        flattened.unshift({ key: curr.key, type: curr.type });
+        curr = curr.prev;
+    }
+    let name = flattened[0].key;
+    for (let i = 1; i < flattened.length; ++i) {
+        name += flattened[i].type === "literal" ? `["${flattened[i].key}"]` : `[${flattened[i].key}]`;
+    }
+    return name;
+}
+
+function printObjectPath(path: ObjectPath) {
+    const flattened = [];
+    let curr: ObjectPath | undefined = path;
+    while (curr) {
+        flattened.unshift({ key: curr.key, type: curr.type });
+        curr = curr.prev;
+    }
+    const initialIndex = Math.min(flattened.length -1 , 1);
+    let name = flattened[initialIndex].key;
+    for (let i = initialIndex + 1; i < flattened.length; ++i) {
+        name += flattened[i].type === "literal" ? `.${flattened[i].key}` : `[$\{${flattened[i].key}}]`;
+    }
+    return name;
+}
+

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -167,7 +167,8 @@ function generateInput(context: CompilationContext, varType: GraphQLInputType,
                         errors.push(new GraphQLError('Variable "$${varName}" got invalid value '
                         + inspect(${currentInput}) + "; " +
                         'Expected type ${varType.name}; ${
-                  varType.name} cannot represent non 32-bit signed integer value: ' + inspect(${currentInput}), ${errorLocation}));
+                  varType.name} cannot represent non 32-bit signed integer value: ' + inspect(${
+                    currentInput}), ${errorLocation}));
                       } else {
                         ${currentOutput} = ${currentInput};
                       }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -81,7 +81,6 @@ export function compileVariableParsing(
 
     body += "if (errors.length > 0) {return {errors, coerced: undefined};}";
     body += "return {errors: undefined, coerced};\n}";
-    // console.log(body);
     return Function
         .apply(null, ["coerced", "GraphQLError", "inspect"].concat(Array.from(dependencies.keys())).concat(body))
         .apply(null, [coercedValues, GraphQLError, inspect].concat(Array.from(dependencies.values())));
@@ -208,7 +207,7 @@ function generateInput(context: CompilationContext, varType: GraphQLInputType,
         const subContext = createSubCompilationContext(context);
         subContext.responsePath = addPath(subContext.responsePath, index, "variable");
         subContext.inputPath = addPath(subContext.inputPath, index, "variable");
-        subContext.depth++; // TODO test depth
+        subContext.depth++;
         body += `
             if (Array.isArray(${currentInput})) {
                 ${currentOutput} = [];

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -174,18 +174,18 @@ function generateInput(context: CompilationContext, varType: GraphQLInputType, v
         context.dependencies.set(`${varType.name}getValue`, varType.getValue);
         body += `
             if (typeof ${currentInput} === "string") { 
-                const enumValue = ${varType.name}getValue(value);
+              const enumValue = ${varType.name}getValue(value);
               if (enumValue) {
                 ${currentOutput} = enumValue.value;
               } else {
                 errors.push(new GraphQLError('Variable "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
-            }
+              }
             } else {
                 errors.push(new GraphQLError('Variable "$${varName}" of required type "${varType}" was bad.', ${errorLocation}));
             }
             `;
     } else if (isListType(varType)) {
-        context.errorMessage =`'Variable "$${printObjectPath(context.inputPath)}" got invalid value ' + inspect(${currentInput}) + '; '`;
+        context.errorMessage =`'Variable "$${varName}" got invalid value ' + inspect(${currentInput}) + '; '`;
         const hasValueName = hasValue(context.inputPath);
         const index = `idx${context.depth}`;
 
@@ -282,7 +282,7 @@ function printObjectPath(path: ObjectPath) {
         curr = curr.prev;
     }
     const initialIndex = Math.min(flattened.length -1 , 1);
-    let name = flattened[initialIndex].key;
+    let name = "value";
     for (let i = initialIndex + 1; i < flattened.length; ++i) {
         name += flattened[i].type === "literal" ? `.${flattened[i].key}` : `[$\{${flattened[i].key}}]`;
     }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -86,8 +86,10 @@ export function compileVariableParsing(
         .apply(null, [coercedValues, GraphQLError, inspect].concat(Array.from(dependencies.values())));
 }
 
-const MAX_INT = 2147483647;
-const MIN_INT = -2147483648;
+// Int Scalars represent 32 bits
+// https://graphql.github.io/graphql-spec/June2018/#sec-Int
+const MAX_32BIT_INT = 2147483647;
+const MIN_32BIT_INT = -2147483648;
 
 function generateInput(context: CompilationContext, varType: GraphQLInputType,
                        varName: string, hasValueName: string, wrapInList: boolean) {
@@ -163,7 +165,7 @@ function generateInput(context: CompilationContext, varType: GraphQLInputType,
             case GraphQLInt.name:
                 body += `
                     if (Number.isInteger(${currentInput})) {
-                      if (${currentInput} > ${MAX_INT} || ${currentInput} < ${MIN_INT}) {
+                      if (${currentInput} > ${MAX_32BIT_INT} || ${currentInput} < ${MIN_32BIT_INT}) {
                         errors.push(new GraphQLError('Variable "$${varName}" got invalid value '
                         + inspect(${currentInput}) + "; " +
                         'Expected type ${varType.name}; ${

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,15 +18,29 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/runtime@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
+  integrity sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  dependencies:
+    any-observable "^0.3.0"
+
 "@types/benchmark@^1.0.31":
   version "1.0.31"
   resolved "https://registry.yarnpkg.com/@types/benchmark/-/benchmark-1.0.31.tgz#2dd3514e93396f362ba5551a7c9ff0da405c1d38"
   integrity sha512-F6fVNOkGEkSdo/19yWYOwVKGvzbTeWkR/XQYBKtGBQ9oGRjBN9f/L4aJI4sDcVPJO58Y1CJZN8va9V2BhrZapA==
 
-"@types/graphql@^14.0.3":
-  version "14.0.3"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.0.3.tgz#389e2e5b83ecdb376d9f98fae2094297bc112c1c"
-  integrity sha512-TcFkpEjcQK7w8OcrQcd7iIBPjU0rdyi3ldj6d0iJ4PPSzbWqPBvXj9KSwO14hTOX2dm9RoiH7VuxksJLNYdXUQ==
+"@types/graphql@^14.2.0":
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.2.0.tgz#74e1da5f2a4a744ac6eb3ed57b48242ea9367202"
+  integrity sha512-lELg5m6eBOmATWyCZl8qULEOvnPIUG6B443yXKj930glXIgwQirIBPp5rthP2amJW0YSzUg2s5sfgba4mRRCNw==
 
 "@types/jest@^23.3.5":
   version "23.3.5"
@@ -98,10 +112,10 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.4.tgz#247d5274110db653706b550fcc2b797ca28cfc59"
-  integrity sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==
+ajv@^6.8.1:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -134,6 +148,11 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
+  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -201,6 +220,18 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
+
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -549,6 +580,20 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
@@ -571,7 +616,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -586,6 +631,15 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.3.1, chalk@^2.4.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -610,6 +664,21 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  integrity sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -680,6 +749,11 @@ commander@^2.12.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
+commander@^2.14.1, commander@^2.9.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
 commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
@@ -722,12 +796,33 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cosmiconfig@^5.0.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
+  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.0"
+    parse-json "^4.0.0"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
   dependencies:
     lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+cross-spawn@^6.0.0:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  integrity sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
 
@@ -759,6 +854,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.1.0"
     whatwg-url "^7.0.0"
 
+date-fns@^1.27.2:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -773,6 +873,13 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -782,6 +889,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -793,10 +905,10 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+deepmerge@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
+  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -833,6 +945,18 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+del@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-3.0.0.tgz#53ecf699ffcbcb39637691ab13baf160819766e5"
+  integrity sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=
+  dependencies:
+    globby "^6.1.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    p-map "^1.1.1"
+    pify "^3.0.0"
+    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -881,7 +1005,19 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-error-ex@^1.2.0:
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+  integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
+end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
+
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
@@ -908,7 +1044,7 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -967,6 +1103,19 @@ execa@^0.7.0:
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -1088,13 +1237,13 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-json-stringify@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-1.9.1.tgz#fc4c13fc93d54d21e0deb738e40abe31d35fd756"
-  integrity sha512-vBXDKcJtoruWZeoqq/ViqJ3VxZH5LimgBTczIPe3x6m6XAgNr7fpAdPml81K+kb+rVl4hTJa/6iMVB62Fus+1A==
+fast-json-stringify@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-1.13.0.tgz#fd9bbc65a5ac083a8f4b53528fe21f7baa0ff0f7"
+  integrity sha512-3B+ENtJyVFBbcTodTQ0VC8NMWvb7R33S8RetnhjMJ12Nw85Hf4Ku9Enm8xqY6llLlmXUU+iNJ49c3/+C3/HiJw==
   dependencies:
-    ajv "^6.5.4"
-    deepmerge "^2.1.1"
+    ajv "^6.8.1"
+    deepmerge "^3.0.0"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1107,6 +1256,21 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
+
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -1142,6 +1306,11 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -1156,6 +1325,11 @@ find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+fn-name@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
+  integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1215,6 +1389,15 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+g-status@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/g-status/-/g-status-2.0.2.tgz#270fd32119e8fc9496f066fe5fe88e0a6bc78b97"
+  integrity sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==
+  dependencies:
+    arrify "^1.0.1"
+    matcher "^1.0.0"
+    simple-git "^1.85.0"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1234,10 +1417,22 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
+  integrity sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -1266,7 +1461,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -1283,15 +1478,26 @@ globals@^9.18.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  integrity sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=
+  dependencies:
+    array-union "^1.0.1"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphql@^14.0.2:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
-  integrity sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==
+graphql@^14.2.1:
+  version "14.2.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.2.1.tgz#779529bf9a01e7207b977a54c20670b48ca6e95c"
+  integrity sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==
   dependencies:
     iterall "^1.2.2"
 
@@ -1432,6 +1638,14 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -1444,6 +1658,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -1555,6 +1774,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -1583,6 +1807,11 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
   integrity sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
 is-finite@^1.0.0:
   version "1.0.2"
@@ -1615,6 +1844,13 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-glob@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -1634,6 +1870,37 @@ is-number@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
+
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+  integrity sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
+  integrity sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.1.tgz#8ef5b7de50437a3fdca6b4e865ef7aa55cb48036"
+  integrity sha1-jvW33lBDej/cprToZe96pVy0gDY=
+  dependencies:
+    path-is-inside "^1.0.1"
+
 is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -1651,12 +1918,22 @@ is-primitive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
   integrity sha1-IHurkWOEmcB7Kt8kCkGochADRXU=
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -2127,6 +2404,14 @@ js-yaml@^3.12.0, js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.0.tgz#38ee7178ac0eea2c97ff6d96fff4b18c7d8cf98e"
+  integrity sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -2168,6 +2453,11 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
   integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -2265,6 +2555,81 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lint-staged@^8.1.5:
+  version "8.1.5"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.1.5.tgz#372476fe1a58b8834eb562ed4c99126bd60bdd79"
+  integrity sha512-e5ZavfnSLcBJE1BTzRTqw6ly8OkqVyO3GL2M6teSmTBYQ/2BuueD5GIt2RPsP31u/vjKdexUyDCxSyK75q4BDA==
+  dependencies:
+    chalk "^2.3.1"
+    commander "^2.14.1"
+    cosmiconfig "^5.0.2"
+    debug "^3.1.0"
+    dedent "^0.7.0"
+    del "^3.0.0"
+    execa "^1.0.0"
+    find-parent-dir "^0.3.0"
+    g-status "^2.0.2"
+    is-glob "^4.0.0"
+    is-windows "^1.0.2"
+    listr "^0.14.2"
+    listr-update-renderer "^0.5.0"
+    lodash "^4.17.11"
+    log-symbols "^2.2.0"
+    micromatch "^3.1.8"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    path-is-inside "^1.0.2"
+    pify "^3.0.0"
+    please-upgrade-node "^3.0.2"
+    staged-git-files "1.1.2"
+    string-argv "^0.0.2"
+    stringify-object "^3.2.2"
+    yup "^0.26.10"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+  integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
+listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
+  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+  dependencies:
+    chalk "^2.4.1"
+    cli-cursor "^2.1.0"
+    date-fns "^1.27.2"
+    figures "^2.0.0"
+
+listr@^0.14.2:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
+  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.5.0"
+    p-map "^2.0.0"
+    rxjs "^6.3.3"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2294,10 +2659,33 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -2337,6 +2725,13 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+matcher@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/matcher/-/matcher-1.1.1.tgz#51d8301e138f840982b338b116bb0c09af62c1c2"
+  integrity sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==
+  dependencies:
+    escape-string-regexp "^1.0.4"
 
 math-random@^1.0.1:
   version "1.0.1"
@@ -2381,7 +2776,7 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.4:
+micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -2515,6 +2910,11 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2584,12 +2984,28 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
+npm-path@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
+  integrity sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  integrity sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.1.2"
@@ -2616,7 +3032,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -2665,12 +3081,19 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -2738,6 +3161,16 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+  integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
+
+p-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.0.0.tgz#be18c5a5adeb8e156460651421aceca56c213a50"
+  integrity sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -2759,6 +3192,14 @@ parse-json@^2.2.0:
   integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse5@4.0.0:
   version "4.0.0"
@@ -2787,7 +3228,12 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
-path-key@^2.0.0:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+  integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
@@ -2816,6 +3262,11 @@ pify@^2.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
   integrity sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -2839,6 +3290,13 @@ platform@^1.3.3:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
   integrity sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==
+
+please-upgrade-node@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -2891,6 +3349,11 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
+property-expr@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
+  integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -2900,6 +3363,14 @@ psl@^1.1.24:
   version "1.1.29"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
   integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -2976,6 +3447,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regex-cache@^0.4.2:
   version "0.4.4"
@@ -3095,10 +3571,25 @@ resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+rimraf@^2.2.8:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
@@ -3111,6 +3602,13 @@ rsvp@^3.3.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
   integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
+
+rxjs@^6.3.3:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -3149,6 +3647,11 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0:
   version "5.6.0"
@@ -3202,6 +3705,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
+simple-git@^1.85.0:
+  version "1.110.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.110.0.tgz#54eb179089d055a7783d32399246cebc9d9933e9"
+  integrity sha512-UYY0rQkknk0P5eb+KW+03F4TevZ9ou0H+LoGaj7iiVgpnZH4wdj/HTViy/1tNNkmIPcmtxuBqXWiYt2YwlRKOQ==
+  dependencies:
+    debug "^4.0.1"
+
 sisteransi@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
@@ -3211,6 +3721,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+  integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -3342,6 +3857,11 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
   integrity sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=
 
+staged-git-files@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-1.1.2.tgz#4326d33886dc9ecfa29a6193bf511ba90a46454b"
+  integrity sha512-0Eyrk6uXW6tg9PYkhi/V/J4zHp33aNyi2hOCmhFLqLTIhbgqWn5jlSzI+IU0VqrZq6+DbHcabQl/WP6P3BG0QA==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -3354,6 +3874,11 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+string-argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
+  integrity sha1-2sMECGkMIfPDYwo/86BYd73L1zY=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -3386,6 +3911,15 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-object@^3.2.2:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -3442,10 +3976,20 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
   integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
+
+synchronous-promise@^2.0.5:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.7.tgz#3574b3d2fae86b145356a4b89103e1577f646fe3"
+  integrity sha512-16GbgwTmFMYFyQMLvtQjvNWh30dsFe1cAW5Fg1wm5+dg84L9Pe36mftsIRU95/W2YsISxsz/xq4VB23sqpgb/A==
 
 tar@^4:
   version "4.4.6"
@@ -3511,6 +4055,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
+
 tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
@@ -3559,7 +4108,7 @@ ts-node@^7.0.1:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -3771,7 +4320,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.12, which@^1.2.9, which@^1.3.0:
+which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -3802,6 +4351,14 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
 
 wrappy@1:
   version "1.0.2"
@@ -3880,3 +4437,15 @@ yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
   integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
+
+yup@^0.26.10:
+  version "0.26.10"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.26.10.tgz#3545839663289038faf25facfc07e11fd67c0cb1"
+  integrity sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==
+  dependencies:
+    "@babel/runtime" "7.0.0"
+    fn-name "~2.0.1"
+    lodash "^4.17.10"
+    property-expr "^1.5.0"
+    synchronous-promise "^2.0.5"
+    toposort "^2.0.2"


### PR DESCRIPTION
Once ready it will replace the `getVariableValues` from `graphql-js`

These are the current results
```
graphql-js x 4,009 ops/sec ±4.79% (77 runs sampled)
graphql-jit - default x 139,388 ops/sec ±2.63% (75 runs sampled)
graphql-jit - default no leaf x 157,109 ops/sec ±2.56% (76 runs sampled)
graphql-jit - compiled x 200,618 ops/sec ±2.68% (75 runs sampled)
graphql-jit - compiled no leaf x 247,419 ops/sec ±2.74% (74 runs sampled)
Fastest is graphql-jit - compiled no leaf
```