### PR TITLE
Add support for skipping generating stack traces.

### DIFF
--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -46,6 +46,7 @@ describe("error generation", () => {
   test("is instanceOf upstream error", () => {
     const resp = executeTestQuery("{ b }", true, { b: new Error() });
     expect(resp.errors[0] instanceof GraphQLError).toBeTruthy();
+    expect(resp.errors[0] instanceof Error).toBeTruthy();
   });
   describe("stack capture", () => {
     test("capture the stack", () => {

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -7,7 +7,6 @@ import {
 } from "graphql";
 import { compileQuery } from "../execution";
 
-const error = new Error("original");
 const schema = new GraphQLSchema({
   query: new GraphQLObjectType({
     name: "TestType",
@@ -20,27 +19,57 @@ const schema = new GraphQLSchema({
       },
       b: {
         type: GraphQLString,
-        resolve() {
-          throw error;
+        resolve({ b }: { b: Error }) {
+          throw b;
         }
       }
     }
   })
 });
 
-function executeTestQuery(query: string) {
+function executeTestQuery(
+  query: string,
+  captureStackErrors: boolean,
+  root: any = {}
+) {
   const ast = parse(query);
-  const compiled: any = compileQuery(schema, ast, "");
-  return compiled.query({}, undefined, {});
+  const compiled: any = compileQuery(schema, ast, "", { captureStackErrors });
+  return compiled.query(root, undefined, {});
 }
 
 describe("error generation", () => {
   test("includes original error", () => {
-    const resp = executeTestQuery("{ b }");
+    const error = new Error("original");
+    const resp = executeTestQuery("{ b }", true, { b: error });
     expect(resp.errors[0].originalError).toBe(error);
   });
   test("is instanceOf upstream error", () => {
-    const resp = executeTestQuery("{ b }");
+    const resp = executeTestQuery("{ b }", true, { b: new Error() });
     expect(resp.errors[0] instanceof GraphQLError).toBeTruthy();
+  });
+  describe("stack capture", () => {
+    test("capture the stack", () => {
+      const error = "test";
+      const resp = executeTestQuery("{ b }", true, { b: error });
+      expect(resp.errors[0].originalError).toBe(error);
+      expect(resp.errors[0].stack).toBeDefined();
+    });
+    test("copies the stack if available", () => {
+      const resp = executeTestQuery("{ b }", false, { b: new Error() });
+      expect(resp.errors[0].stack).toBeDefined();
+    });
+    test("does not capture the stack if set in options", () => {
+      const error = "test";
+      const resp = executeTestQuery("{ b }", false, { b: error });
+      expect(resp.errors[0].originalError).toBe(error);
+      expect(resp.errors[0].stack).not.toBeDefined();
+    });
+    test("fallbacks if Error.captureStackTrace is not defined", () => {
+      const captureStackTrace = Error.captureStackTrace;
+      Error.captureStackTrace = (null as unknown) as any;
+      const resp = executeTestQuery("{ b }", true, { b: "error" });
+      expect(resp.errors[0].stack).toBeDefined();
+      Error.captureStackTrace = captureStackTrace;
+    });
   });
 });

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -29,46 +29,48 @@ const schema = new GraphQLSchema({
 
 function executeTestQuery(
   query: string,
-  captureStackErrors: boolean,
+  disablingCapturingStackErrors: boolean,
   root: any = {}
 ) {
   const ast = parse(query);
-  const compiled: any = compileQuery(schema, ast, "", { captureStackErrors });
+  const compiled: any = compileQuery(schema, ast, "", {
+    disablingCapturingStackErrors
+  });
   return compiled.query(root, undefined, {});
 }
 
 describe("error generation", () => {
   test("includes original error", () => {
     const error = new Error("original");
-    const resp = executeTestQuery("{ b }", true, { b: error });
+    const resp = executeTestQuery("{ b }", false, { b: error });
     expect(resp.errors[0].originalError).toBe(error);
   });
   test("is instanceOf upstream error", () => {
-    const resp = executeTestQuery("{ b }", true, { b: new Error() });
+    const resp = executeTestQuery("{ b }", false, { b: new Error() });
     expect(resp.errors[0] instanceof GraphQLError).toBeTruthy();
     expect(resp.errors[0] instanceof Error).toBeTruthy();
   });
   describe("stack capture", () => {
     test("capture the stack", () => {
       const error = "test";
-      const resp = executeTestQuery("{ b }", true, { b: error });
+      const resp = executeTestQuery("{ b }", false, { b: error });
       expect(resp.errors[0].originalError).toBe(error);
       expect(resp.errors[0].stack).toBeDefined();
     });
     test("copies the stack if available", () => {
-      const resp = executeTestQuery("{ b }", false, { b: new Error() });
+      const resp = executeTestQuery("{ b }", true, { b: new Error() });
       expect(resp.errors[0].stack).toBeDefined();
     });
     test("does not capture the stack if set in options", () => {
       const error = "test";
-      const resp = executeTestQuery("{ b }", false, { b: error });
+      const resp = executeTestQuery("{ b }", true, { b: error });
       expect(resp.errors[0].originalError).toBe(error);
       expect(resp.errors[0].stack).not.toBeDefined();
     });
     test("fallbacks if Error.captureStackTrace is not defined", () => {
       const captureStackTrace = Error.captureStackTrace;
       Error.captureStackTrace = (null as unknown) as any;
-      const resp = executeTestQuery("{ b }", true, { b: "error" });
+      const resp = executeTestQuery("{ b }", false, { b: "error" });
       expect(resp.errors[0].stack).toBeDefined();
       Error.captureStackTrace = captureStackTrace;
     });

--- a/src/error.ts
+++ b/src/error.ts
@@ -8,7 +8,8 @@ export function GraphQLError(
         message: string,
         locations?: ReadonlyArray<SourceLocation>,
         path?: ReadonlyArray<string | number>,
-        originalError?: Error & { extensions?: any }
+        originalError?: Error & { extensions?: any },
+        skipStackCapturing?: boolean
     ) {
         const extensions = originalError && originalError.extensions;
         Object.defineProperties(this, {
@@ -42,14 +43,16 @@ export function GraphQLError(
                 writable: true,
                 configurable: true,
             });
-        } else if (Error.captureStackTrace) {
-            Error.captureStackTrace(this, GraphQLError);
-        } else {
-            Object.defineProperty(this, "stack", {
-                value: Error().stack,
-                writable: true,
-                configurable: true,
-            });
+        } else if (!skipStackCapturing) {
+            if (Error.captureStackTrace) {
+                Error.captureStackTrace(this, GraphQLError);
+            } else {
+                Object.defineProperty(this, "stack", {
+                    value: Error().stack,
+                    writable: true,
+                    configurable: true,
+                });
+            }
         }
 }
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -55,6 +55,11 @@ export interface CompilerOptions {
     // only safe for use if the output is completely correct.
     disableLeafSerialization: boolean;
 
+    // Disable builtin scalars and enum serialization
+    // which is responsible for coercion,
+    // only safe for use if the output is completely correct.
+    captureStackErrors: boolean;
+
     // Map of serializers to override
     // the key should be the name passed to the Scalar or Enum type
     customSerializers: { [key: string]: (v: any) => any};
@@ -134,6 +139,7 @@ export function compileQuery(
     }
     try {
         const options = {
+            captureStackErrors: true,
             customJSONSerializer: false,
             disableLeafSerialization: false,
             customSerializers: {},
@@ -385,12 +391,13 @@ function compileDeferredFields(context: CompilationContext): string {
                 isNonNullType(fieldType)
                     ? GLOBAL_NULL_ERRORS_NAME
                     : GLOBAL_ERRORS_NAME
-                }.push(${getErrorObject(
+                }.push(${createErrorObject(
+                context,
                 fieldNodes,
                 responsePath,
                 "err.message != null ? err.message : err",
                 "err"
-            )});
+            )/* TODO: test why no return here*/});
     }
     ${generateUniqueDeclarations(subContext)}
     parent.${name} = ${nodeBody};\n
@@ -434,7 +441,8 @@ function compileType(
         const nullErrorStr = `"Cannot return null for non-nullable field ${
             parentType.name
             }.${getFieldNodesName(fieldNodes)}."`;
-        body += `(${GLOBAL_NULL_ERRORS_NAME}.push(${getErrorObject(
+        body += `(${GLOBAL_NULL_ERRORS_NAME}.push(${createErrorObject(
+            context,
             fieldNodes,
             previousPath,
             nullErrorStr
@@ -447,7 +455,8 @@ function compileType(
     body += "(";
     // value can be an error obj
     const errorPath = `${sourcePath}.message != null ? ${sourcePath}.message : ${sourcePath}`;
-    body += `${sourcePath} instanceof Error ? (${errorDestination}.push(${getErrorObject(
+    body += `${sourcePath} instanceof Error ? (${errorDestination}.push(${createErrorObject(
+        context,
         fieldNodes,
         previousPath,
         errorPath,
@@ -521,7 +530,8 @@ function compileLeafType(
         body += getSerializerName(type.name);
         body += `(${originPaths.join(
             "."
-        )}, (message) => {${errorDestination}.push(${getErrorObject(
+        )}, (message) => {${errorDestination}.push(${createErrorObject(
+            context,
             fieldNodes,
             previousPath,
             "message"
@@ -660,7 +670,8 @@ function compileAbstractType(
     return `((nodeType, err) =>
   {
     if (err != null) {
-      ${errorDestination}.push(${getErrorObject(
+      ${errorDestination}.push(${createErrorObject(
+        context,
         fieldNodes,
         previousPath,
         "err.message != null ? err.message : err",
@@ -669,7 +680,8 @@ function compileAbstractType(
       return null;
     }
     if (nodeType == null) {
-      ${errorDestination}.push(${getErrorObject(
+      ${errorDestination}.push(${createErrorObject(
+        context,
         fieldNodes,
         previousPath,
         nullTypeError
@@ -680,7 +692,8 @@ function compileAbstractType(
     switch(${finalTypeName}) {
       ${collectedTypes}
       default:
-      ${errorDestination}.push(${getErrorObject(
+      ${errorDestination}.push(${createErrorObject(
+        context,
         fieldNodes,
         previousPath,
         noTypeError
@@ -738,7 +751,8 @@ function compileListType(
     const errorMessage = `"Expected Iterable, but did not find one for field ${
         parentType.name
         }.${getFieldNodesName(fieldNodes)}."`;
-    const errorCase = `(${errorDestination}.push(${getErrorObject(
+    const errorCase = `(${errorDestination}.push(${createErrorObject(
+        context,
         fieldNodes,
         responsePath,
         errorMessage
@@ -775,7 +789,7 @@ function unpromisify(
         value
             .then(
                 (res: any) => cb(res, null),
-                (err: Error) => (err != null ? cb(null, err) : cb(null, new Error("")))
+                (err: Error) => (err != null ? cb(null, err) : cb(null, new (CustomGraphQLError as any)("")))
             )
             .catch(errorHandler);
         return;
@@ -1208,7 +1222,8 @@ function getFieldNodesName(nodes: FieldNode[]) {
         : nodes[0].name.value;
 }
 
-function getErrorObject(
+function createErrorObject(
+    context: CompilationContext,
     nodes: FieldNode[],
     path: ObjectPath,
     message: string,
@@ -1217,7 +1232,8 @@ function getErrorObject(
     return `new GraphQLError(${message},
     ${JSON.stringify(computeLocations(nodes))},
       ${serializeResponsePathAsArray(path)},
-      ${originalError ? originalError : "undefined"})`;
+      ${originalError ? originalError : "undefined"},
+      ${context.options.captureStackErrors ? "false" : "true"})`;
 }
 
 function getResolverName(parentName: string, name: string) {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -42,7 +42,7 @@ import {
     ObjectPath,
     resolveFieldDef
 } from "./ast";
-import {GraphQLError as CustomGraphQLError} from "./error";
+import {GraphQLError as GraphqlJitError} from "./error";
 import { queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
 import {compileVariableParsing} from "./variables";
@@ -265,7 +265,7 @@ export function createBoundQuery(
             executor,
             resolveIfDone,
             safeMap,
-            CustomGraphQLError,
+            GraphqlJitError,
             ...resolvers
         ]);
         if (result) {
@@ -789,7 +789,7 @@ function unpromisify(
         value
             .then(
                 (res: any) => cb(res, null),
-                (err: Error) => (err != null ? cb(null, err) : cb(null, new (CustomGraphQLError as any)("")))
+                (err: Error) => (err != null ? cb(null, err) : cb(null, new (GraphqlJitError as any)("")))
             )
             .catch(errorHandler);
         return;
@@ -1440,7 +1440,7 @@ function normalizeErrors(err: Error[] | Error): GraphQLError[] {
 
 function normalizeError(err: Error): GraphQLError {
     return err instanceof GraphQLError ? err :
-        new (CustomGraphQLError as any)(err.message, (err as any).locations, (err as any).path, err);
+        new (GraphqlJitError as any)(err.message, (err as any).locations, (err as any).path, err);
 }
 
 /**

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -55,10 +55,8 @@ export interface CompilerOptions {
     // only safe for use if the output is completely correct.
     disableLeafSerialization: boolean;
 
-    // Disable builtin scalars and enum serialization
-    // which is responsible for coercion,
-    // only safe for use if the output is completely correct.
-    captureStackErrors: boolean;
+    // Disable capturing the stack trace of errors.
+    disablingCapturingStackErrors: boolean;
 
     // Map of serializers to override
     // the key should be the name passed to the Scalar or Enum type
@@ -139,7 +137,7 @@ export function compileQuery(
     }
     try {
         const options = {
-            captureStackErrors: true,
+            disablingCapturingStackErrors: false,
             customJSONSerializer: false,
             disableLeafSerialization: false,
             customSerializers: {},
@@ -1233,7 +1231,7 @@ function createErrorObject(
     ${JSON.stringify(computeLocations(nodes))},
       ${serializeResponsePathAsArray(path)},
       ${originalError ? originalError : "undefined"},
-      ${context.options.captureStackErrors ? "false" : "true"})`;
+      ${context.options.disablingCapturingStackErrors ? "true" : "false"})`;
 }
 
 function getResolverName(parentName: string, name: string) {


### PR DESCRIPTION
Stack generation is an expensive operation that might be skippable for certain scenarios.