### PR TITLE
Fix reused object in variable parsing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/__tests__/variables.test.ts
+++ b/src/__tests__/variables.test.ts
@@ -712,6 +712,43 @@ describe("Execute: Handles inputs", () => {
       });
     });
 
+    test("does not reuse previous inputs", async () => {
+      const spy = jest.fn().mockReturnValue("test");
+      const schema = new GraphQLSchema({
+        query: new GraphQLObjectType({
+          name: "TestType",
+          fields: {
+            inputRecorder: {
+              type: GraphQLString,
+              args: { input: { type: GraphQLString } },
+              resolve: spy
+            }
+          }
+        })
+      });
+
+      const document = `
+        query ($string: String) {
+          inputRecorder(input: $string)
+        }
+      `;
+      const compiled: any = compileQuery(schema, parse(document), "");
+      compiled.query(undefined, undefined, { string: "id" });
+      expect(spy).toHaveBeenCalledWith(
+        undefined,
+        { input: "id" },
+        undefined,
+        expect.any(Object)
+      );
+      compiled.query(undefined, undefined, {});
+      expect(spy).toHaveBeenCalledWith(
+        undefined,
+        {},
+        undefined,
+        expect.any(Object)
+      );
+    });
+
     test("allows nullable inputs to be set to a value directly", async () => {
       const result = await executeQuery(`
         {


### PR DESCRIPTION
The default value object was created once on compilation and reused on every query.
This was a mistake that is harmless when all values are always specified.

When one of the inputs is sometimes not present, then this bugs show up with the previous value that it was set to.

This PR correctly creates the object inside the instantiated function.