### PR TITLE
feat: provide expanded fields in resolve info for lookaheads

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/jest": "^24.0.11",
     "@types/json-schema": "^7.0.1",
     "@types/lodash.memoize": "^4.1.6",
+    "@types/lodash.merge": "^4.6.6",
     "@types/lodash.mergewith": "^4.6.6",
     "@types/node": "^10.11.7",
     "benchmark": "^2.1.4",
@@ -70,7 +71,6 @@
     "typescript": "^3.4.2"
   },
   "dependencies": {
-    "@types/lodash.merge": "^4.6.6",
     "fast-json-stringify": "^1.13.0",
     "json-schema": "^0.2.3",
     "lodash.memoize": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/jest": "^24.0.11",
     "@types/json-schema": "^7.0.1",
     "@types/lodash.memoize": "^4.1.6",
-    "@types/lodash.merge": "^4.6.6",
+    "@types/lodash.mergewith": "^4.6.6",
     "@types/node": "^10.11.7",
     "benchmark": "^2.1.4",
     "codecov": "^3.3.0",
@@ -70,10 +70,12 @@
     "typescript": "^3.4.2"
   },
   "dependencies": {
+    "@types/lodash.merge": "^4.6.6",
     "fast-json-stringify": "^1.13.0",
     "json-schema": "^0.2.3",
     "lodash.memoize": "^4.1.2",
-    "lodash.merge": "^4.6.1"
+    "lodash.merge": "^4.6.1",
+    "lodash.mergewith": "^4.6.1"
   },
   "lint-staged": {
     "linters": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/graphql": "^14.2.0",
     "@types/jest": "^24.0.11",
     "@types/json-schema": "^7.0.1",
+    "@types/lodash.memoize": "^4.1.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/node": "^10.11.7",
     "benchmark": "^2.1.4",
@@ -71,6 +72,7 @@
   "dependencies": {
     "fast-json-stringify": "^1.13.0",
     "json-schema": "^0.2.3",
+    "lodash.memoize": "^4.1.2",
     "lodash.merge": "^4.6.1"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "benchmark": "^2.1.4",
     "codecov": "^3.3.0",
     "graphql": "^14.2.1",
+    "graphql-tools": "^4.0.4",
     "jest": "^24.7.1",
     "lint-staged": "^8.1.5",
     "prettier": "^1.16.4",

--- a/src/__tests__/__snapshots__/json.test.ts.snap
+++ b/src/__tests__/__snapshots__/json.test.ts.snap
@@ -18,6 +18,61 @@ Object {
                     "null",
                   ],
                 },
+                "pic": Object {
+                  "properties": Object {
+                    "height": Object {
+                      "type": Array [
+                        "integer",
+                        "null",
+                      ],
+                    },
+                    "url": Object {
+                      "type": Array [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    "width": Object {
+                      "type": Array [
+                        "integer",
+                        "null",
+                      ],
+                    },
+                  },
+                  "type": Array [
+                    "object",
+                    "null",
+                  ],
+                },
+                "recentArticle": Object {
+                  "properties": Object {
+                    "body": Object {
+                      "type": Array [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    "id": Object {
+                      "type": "string",
+                    },
+                    "isPublished": Object {
+                      "type": Array [
+                        "boolean",
+                        "null",
+                      ],
+                    },
+                    "title": Object {
+                      "type": Array [
+                        "string",
+                        "null",
+                      ],
+                    },
+                  },
+                  "type": Array [
+                    "object",
+                    "null",
+                  ],
+                },
               },
               "type": "object",
             },

--- a/src/__tests__/execution.test.ts
+++ b/src/__tests__/execution.test.ts
@@ -268,7 +268,7 @@ describe("Execute: Handles basic execution tasks", () => {
       "rootValue",
       "operation",
       "variableValues",
-      "fields"
+      "fieldExpansion"
     ]);
     expect(info.fieldName).toEqual("test");
     expect(info.fieldNodes).toHaveLength(1);

--- a/src/__tests__/execution.test.ts
+++ b/src/__tests__/execution.test.ts
@@ -267,7 +267,8 @@ describe("Execute: Handles basic execution tasks", () => {
       "fragments",
       "rootValue",
       "operation",
-      "variableValues"
+      "variableValues",
+      "fields"
     ]);
     expect(info.fieldName).toEqual("test");
     expect(info.fieldNodes).toHaveLength(1);

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -9,7 +9,9 @@ import {
   GraphQLObjectType,
   GraphQLSchema,
   GraphQLString,
-  parse
+  parse,
+  GraphQLInt,
+  GraphQLScalarType
 } from "graphql";
 import { buildExecutionContext } from "graphql/execution/execute";
 import { compileQuery } from "../index";
@@ -20,7 +22,20 @@ describe("json schema creator", () => {
     name: "Author",
     fields: () => ({
       id: { type: new GraphQLNonNull(GraphQLID) },
-      name: { type: GraphQLString }
+      name: { type: GraphQLString },
+      pic: {
+        type: new GraphQLObjectType({
+          name: "Pic",
+          fields: {
+            width: { type: GraphQLInt },
+            height: { type: GraphQLInt },
+            url: { type: GraphQLString }
+          }
+        })
+      },
+      recentArticle: {
+        type: BlogArticle
+      }
     })
   });
 
@@ -139,7 +154,7 @@ describe("json schema creator", () => {
       expect(prepared.stringify).not.toBe(JSON.stringify);
       expect(prepared.stringify(response)).toEqual(JSON.stringify(response));
     });
-    test("valid response serialization", async () => {
+    test("valid response serialization 2", async () => {
       const prepared: any = compileQuery(blogSchema, parse(query), "", {
         customJSONSerializer: false
       });

--- a/src/__tests__/memoize.test.ts
+++ b/src/__tests__/memoize.test.ts
@@ -1,0 +1,60 @@
+import { memoize2, memoize3, memoize4 } from "../memoize";
+
+describe("memoize", () => {
+  describe("2 params", () => {
+    const effectCheck = jest.fn();
+    function add(a: number, b: number) {
+      effectCheck();
+      return a + b;
+    }
+    afterEach(() => {
+      effectCheck.mockReset();
+    });
+    test("should call effect only once", () => {
+      const memoizedAdd = memoize2(add);
+      memoizedAdd(1)(2);
+      memoizedAdd(1)(2);
+      memoizedAdd(1)(2);
+      memoizedAdd(1)(2);
+      expect(effectCheck).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("3 params", () => {
+    const effectCheck = jest.fn();
+    function add(a: number, b: number, c: number) {
+      effectCheck();
+      return a + b + c;
+    }
+    afterEach(() => {
+      effectCheck.mockReset();
+    });
+    test("should call effect only once", () => {
+      const memoizedAdd = memoize3(add);
+      memoizedAdd(1)(2)(3);
+      memoizedAdd(1)(2)(3);
+      memoizedAdd(1)(2)(3);
+      memoizedAdd(1)(2)(3);
+      expect(effectCheck).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("4 params", () => {
+    const effectCheck = jest.fn();
+    function add(a: number, b: number, c: number, d: number) {
+      effectCheck();
+      return a + b + c + d;
+    }
+    afterEach(() => {
+      effectCheck.mockReset();
+    });
+    test("should call effect only once", () => {
+      const memoizedAdd = memoize4(add);
+      memoizedAdd(1)(2)(3)(4);
+      memoizedAdd(1)(2)(3)(4);
+      memoizedAdd(1)(2)(3)(4);
+      memoizedAdd(1)(2)(3)(4);
+      expect(effectCheck).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/__tests__/memoize.test.ts
+++ b/src/__tests__/memoize.test.ts
@@ -12,10 +12,10 @@ describe("memoize", () => {
     });
     test("should call effect only once", () => {
       const memoizedAdd = memoize2(add);
-      memoizedAdd(1)(2);
-      memoizedAdd(1)(2);
-      memoizedAdd(1)(2);
-      memoizedAdd(1)(2);
+      memoizedAdd(1, 2);
+      memoizedAdd(1, 2);
+      memoizedAdd(1, 2);
+      memoizedAdd(1, 2);
       expect(effectCheck).toHaveBeenCalledTimes(1);
     });
   });
@@ -31,10 +31,10 @@ describe("memoize", () => {
     });
     test("should call effect only once", () => {
       const memoizedAdd = memoize3(add);
-      memoizedAdd(1)(2)(3);
-      memoizedAdd(1)(2)(3);
-      memoizedAdd(1)(2)(3);
-      memoizedAdd(1)(2)(3);
+      memoizedAdd(1, 2, 3);
+      memoizedAdd(1, 2, 3);
+      memoizedAdd(1, 2, 3);
+      memoizedAdd(1, 2, 3);
       expect(effectCheck).toHaveBeenCalledTimes(1);
     });
   });
@@ -50,10 +50,10 @@ describe("memoize", () => {
     });
     test("should call effect only once", () => {
       const memoizedAdd = memoize4(add);
-      memoizedAdd(1)(2)(3)(4);
-      memoizedAdd(1)(2)(3)(4);
-      memoizedAdd(1)(2)(3)(4);
-      memoizedAdd(1)(2)(3)(4);
+      memoizedAdd(1, 2, 3, 4);
+      memoizedAdd(1, 2, 3, 4);
+      memoizedAdd(1, 2, 3, 4);
+      memoizedAdd(1, 2, 3, 4);
       expect(effectCheck).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -1,0 +1,181 @@
+import { GraphQLSchema, DocumentNode, parse } from "graphql";
+import { GraphQLJitResolveInfo } from "../resolve-info";
+import { compileQuery, isCompiledQuery } from "../execution";
+import { makeExecutableSchema } from "graphql-tools";
+
+describe("resolve-info", () => {
+  describe("GraphQLJitResolveInfo - simple types", () => {
+    let inf: any;
+    const schema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          foo: Foo
+        }
+        type Foo {
+          a: String
+          b: Int
+          c: Boolean!
+        }
+      `,
+      resolvers: {
+        Query: {
+          foo(_: any, _1: any, _2: any, info: any) {
+            inf = info;
+          }
+        }
+      }
+    });
+
+    afterEach(() => {
+      inf = undefined;
+    });
+
+    test("all selection fields of the current resolver", async () => {
+      await executeQuery(schema, parse(`query { foo { a b c } }`));
+      expect(inf.fields).toMatchObject({
+        Foo: expect.arrayContaining(["a", "b", "c"])
+      });
+    });
+
+    test("interface fields", async () => {
+      await executeQuery(
+        schema,
+        parse(
+          `
+          query {
+            foo {
+              ...fooFragment1
+              a
+              b
+              ... on Foo {
+                c
+                ...fooFragment1
+              }
+            }
+          }
+          fragment fooFragment1 on Foo {
+            a
+            b
+          }
+          `
+        )
+      );
+
+      expect(inf.fields).toMatchObject({
+        Foo: expect.arrayContaining(["a", "b", "c"])
+      });
+    });
+  });
+
+  describe("jit resolve info for interfaces", () => {
+    let inf: any;
+    const schema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          iBar: IBar
+        }
+        interface IBar {
+          id: ID!
+          title: String
+        }
+        type Bar1 implements IBar {
+          id: ID!
+          title: String
+          b1: Int!
+        }
+        type Bar2 implements IBar {
+          id: ID!
+          title: String
+          b2: Boolean!
+        }
+      `,
+      resolvers: {
+        Query: {
+          iBar(_: any, _1: any, _2: any, info: any) {
+            inf = info;
+          }
+        },
+        IBar: {
+          __resolveType() {
+            return "Bar1";
+          }
+        }
+      }
+    });
+
+    afterEach(() => {
+      inf = undefined;
+    });
+
+    test("compute interface field nodes", async () => {
+      await executeQuery(
+        schema,
+        parse(
+          `
+            query {
+              iBar {
+                id
+                title
+              }
+            }
+          `
+        )
+      );
+
+      expect(inf.fields).toMatchObject({
+        IBar: expect.arrayContaining(["id", "title"])
+      });
+    });
+
+    test("fields per type", async () => {
+      await executeQuery(
+        schema,
+        parse(
+          `
+            query {
+              iBar {
+                id
+                title
+                ... on Bar1 {
+                  b1
+                }
+                ... on Bar2 {
+                  b2
+                }
+              }
+            }
+          `
+        )
+      );
+
+      expect(inf.fields).toMatchObject({
+        IBar: expect.arrayContaining(["id", "title"]),
+        Bar1: expect.arrayContaining(["id", "title", "b1"]),
+        Bar2: expect.arrayContaining(["id", "title", "b2"])
+      });
+    });
+  });
+});
+
+function executeQuery(
+  schema?: GraphQLSchema,
+  document?: DocumentNode,
+  rootValue?: any,
+  contextValue?: any,
+  variableValues?: any,
+  operationName?: string
+) {
+  const prepared: any = compileQuery(
+    schema as any,
+    document as any,
+    operationName || ""
+  );
+  if (!isCompiledQuery(prepared)) {
+    return prepared;
+  }
+  return prepared.query(rootValue, contextValue, variableValues || {});
+}
+
+interface Resolver {
+  (parent: any, params: any, context: any, info: GraphQLJitResolveInfo): any;
+}

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -593,6 +593,17 @@ describe("GraphQLJitResolveInfo", () => {
         `)
       );
       expect(result.errors).not.toBeDefined();
+      expect(infFoos.fieldExpansion).toMatchInlineSnapshot(`
+        Object {
+          "Foo": Object {
+            "bars": Object {
+              "Bar": Object {
+                "strs": true,
+              },
+            },
+          },
+        }
+      `);
     });
 
     // TODO

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -3,7 +3,7 @@ import { compileQuery, isCompiledQuery } from "../execution";
 import { makeExecutableSchema } from "graphql-tools";
 
 describe("GraphQLJitResolveInfo", () => {
-  describe.only("simple types", () => {
+  describe("simple types", () => {
     let inf: any;
     const schema = makeExecutableSchema({
       typeDefs: `
@@ -157,7 +157,7 @@ describe("GraphQLJitResolveInfo", () => {
     });
   });
 
-  describe.only("interfaces", () => {
+  describe("interfaces", () => {
     let inf: any;
     const schema = makeExecutableSchema({
       typeDefs: `
@@ -408,7 +408,7 @@ describe("GraphQLJitResolveInfo", () => {
       inf = undefined;
     });
 
-    test.only("union field nodes", async () => {
+    test("union field nodes", async () => {
       const result = await executeQuery(
         schema,
         parse(
@@ -428,12 +428,16 @@ describe("GraphQLJitResolveInfo", () => {
       );
 
       expect(result.errors).not.toBeDefined();
-      expect(inf.fieldExpansion).toMatchInlineSnapshot();
-
-      // expect(inf.fields).toMatchObject({
-      //   Foo: expect.arrayContaining(["foo"]),
-      //   Bar: expect.arrayContaining(["bar"])
-      // });
+      expect(inf.fieldExpansion).toMatchInlineSnapshot(`
+        Object {
+          "Bar": Object {
+            "bar": true,
+          },
+          "Foo": Object {
+            "foo": true,
+          },
+        }
+      `);
 
       // should not contain the union type as there cannot
       // be a selection set for unions without a specific type
@@ -441,7 +445,7 @@ describe("GraphQLJitResolveInfo", () => {
     });
 
     test("unions with fragments", async () => {
-      await executeQuery(
+      const result = await executeQuery(
         schema,
         parse(
           `
@@ -461,14 +465,21 @@ describe("GraphQLJitResolveInfo", () => {
         )
       );
 
-      expect(inf.fields).toMatchObject({
-        Foo: expect.arrayContaining(["foo"]),
-        Bar: expect.arrayContaining(["bar"])
-      });
+      expect(result.errors).not.toBeDefined();
+      expect(inf.fieldExpansion).toMatchInlineSnapshot(`
+        Object {
+          "Bar": Object {
+            "bar": true,
+          },
+          "Foo": Object {
+            "foo": true,
+          },
+        }
+      `);
     });
 
     test("aggregate multiple selections of the same field", async () => {
-      await executeQuery(
+      const result = await executeQuery(
         schema,
         parse(
           `
@@ -492,10 +503,17 @@ describe("GraphQLJitResolveInfo", () => {
         )
       );
 
-      expect(inf.fields).toMatchObject({
-        Foo: expect.arrayContaining(["foo"]),
-        Bar: expect.arrayContaining(["bar"])
-      });
+      expect(result.errors).not.toBeDefined();
+      expect(inf.fieldExpansion).toMatchInlineSnapshot(`
+        Object {
+          "Bar": Object {
+            "bar": true,
+          },
+          "Foo": Object {
+            "foo": true,
+          },
+        }
+      `);
     });
   });
 });

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -40,14 +40,17 @@ describe("GraphQLJitResolveInfo", () => {
         parse(`query { foo { a d { e } } }`)
       );
       expect(result.errors).not.toBeDefined();
-
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Foo": Object {
-            "a": true,
+            "a": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
             "d": Object {
               "Bar": Object {
-                "e": true,
+                "e": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
               },
             },
           },
@@ -82,9 +85,15 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Foo": Object {
-            "a": true,
-            "b": true,
-            "c": true,
+            "a": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "b": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "c": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -117,7 +126,9 @@ describe("GraphQLJitResolveInfo", () => {
           "Foo": Object {
             "d": Object {
               "Bar": Object {
-                "e": true,
+                "e": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
               },
             },
           },
@@ -148,9 +159,15 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Foo": Object {
-            "a": true,
-            "b": true,
-            "c": true,
+            "a": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "b": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "c": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -217,16 +234,28 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Bar1": Object {
-            "id": true,
-            "title": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Bar2": Object {
-            "id": true,
-            "title": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "IBar": Object {
-            "id": true,
-            "title": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -256,18 +285,34 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Bar1": Object {
-            "b1": true,
-            "id": true,
-            "title": true,
+            "b1": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Bar2": Object {
-            "b2": true,
-            "id": true,
-            "title": true,
+            "b2": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "IBar": Object {
-            "id": true,
-            "title": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -308,18 +353,34 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Bar1": Object {
-            "b1": true,
-            "id": true,
-            "title": true,
+            "b1": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Bar2": Object {
-            "b2": true,
-            "id": true,
-            "title": true,
+            "b2": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "IBar": Object {
-            "id": true,
-            "title": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -357,18 +418,34 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Bar1": Object {
-            "b1": true,
-            "id": true,
-            "title": true,
+            "b1": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Bar2": Object {
-            "b2": true,
-            "id": true,
-            "title": true,
+            "b2": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "IBar": Object {
-            "id": true,
-            "title": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "title": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -431,10 +508,14 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Bar": Object {
-            "bar": true,
+            "bar": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Foo": Object {
-            "foo": true,
+            "foo": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -486,10 +567,14 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Bar": Object {
-            "bar": true,
+            "bar": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Foo": Object {
-            "foo": true,
+            "foo": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -524,10 +609,14 @@ describe("GraphQLJitResolveInfo", () => {
       expect(inf.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Bar": Object {
-            "bar": true,
+            "bar": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Foo": Object {
-            "foo": true,
+            "foo": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -656,40 +745,68 @@ describe("GraphQLJitResolveInfo", () => {
       expect(infNode.fieldExpansion).toMatchInlineSnapshot(`
         Object {
           "Image": Object {
-            "id": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
             "tags": Object {
               "Tag": Object {
-                "id": true,
-                "name": true,
+                "id": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
+                "name": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
               },
             },
-            "url": true,
-            "width": true,
+            "url": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "width": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Media": Object {
             "tags": Object {
               "Tag": Object {
-                "id": true,
-                "name": true,
+                "id": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
+                "name": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
               },
             },
-            "url": true,
+            "url": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Node": Object {
-            "id": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Tag": Object {
-            "id": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Video": Object {
-            "id": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
             "tags": Object {
               "Tag": Object {
-                "id": true,
-                "name": true,
+                "id": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
+                "name": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
               },
             },
-            "url": true,
+            "url": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);
@@ -740,42 +857,66 @@ describe("GraphQLJitResolveInfo", () => {
                 "children": Object {
                   "Div": Object {},
                   "Image": Object {
-                    "url": true,
+                    "url": Object {
+                      Symbol(LeafFieldSymbol): true,
+                    },
                   },
                   "Media": Object {
-                    "url": true,
+                    "url": Object {
+                      Symbol(LeafFieldSymbol): true,
+                    },
                   },
                   "Node": Object {},
                   "Video": Object {
-                    "url": true,
+                    "url": Object {
+                      Symbol(LeafFieldSymbol): true,
+                    },
                   },
                 },
               },
               "Image": Object {
-                "id": true,
+                "id": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
               },
               "Media": Object {},
               "Node": Object {
-                "id": true,
+                "id": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
               },
               "Video": Object {
-                "id": true,
+                "id": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
               },
             },
           },
           "Image": Object {
-            "id": true,
-            "url": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "url": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Media": Object {
-            "url": true,
+            "url": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Node": Object {
-            "id": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
           "Video": Object {
-            "id": true,
-            "url": true,
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "url": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
           },
         }
       `);

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -1,10 +1,9 @@
 import { GraphQLSchema, DocumentNode, parse } from "graphql";
-import { GraphQLJitResolveInfo } from "../resolve-info";
 import { compileQuery, isCompiledQuery } from "../execution";
 import { makeExecutableSchema } from "graphql-tools";
 
-describe("resolve-info", () => {
-  describe("GraphQLJitResolveInfo - simple types", () => {
+describe("GraphQLJitResolveInfo", () => {
+  describe("simple types", () => {
     let inf: any;
     const schema = makeExecutableSchema({
       typeDefs: `
@@ -67,7 +66,7 @@ describe("resolve-info", () => {
     });
   });
 
-  describe("jit resolve info for interfaces", () => {
+  describe("interfaces", () => {
     let inf: any;
     const schema = makeExecutableSchema({
       typeDefs: `
@@ -154,6 +153,134 @@ describe("resolve-info", () => {
         Bar2: expect.arrayContaining(["id", "title", "b2"])
       });
     });
+
+    test("fields per type - with fragments", async () => {
+      await executeQuery(
+        schema,
+        parse(
+          `
+            query {
+              iBar {
+                id
+                title
+                ... on Bar1 {
+                  b1
+                  ...bar1
+                }
+                ... on Bar2 {
+                  b2
+                }
+                ...bar2
+              }
+            }
+            fragment bar1 on Bar1 {
+              id
+              b1
+            }
+            fragment bar2 on Bar2 {
+              title
+              b2
+            }
+          `
+        )
+      );
+
+      expect(inf.fields).toMatchObject({
+        IBar: expect.arrayContaining(["id", "title"]),
+        Bar1: expect.arrayContaining(["id", "title", "b1"]),
+        Bar2: expect.arrayContaining(["id", "title", "b2"])
+      });
+    });
+  });
+
+  describe("unions", () => {
+    let inf: any;
+    const schema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          uBaz: Baz
+        }
+        union Baz = Foo | Bar
+        type Foo {
+          foo: String
+        }
+        type Bar {
+          bar: Int
+        }
+      `,
+      resolvers: {
+        Query: {
+          uBaz(_: any, _1: any, _2: any, info: any) {
+            inf = info;
+          }
+        },
+        Baz: {
+          __resolveType() {
+            return "Foo";
+          }
+        }
+      }
+    });
+
+    afterEach(() => {
+      inf = undefined;
+    });
+
+    test("union field nodes", async () => {
+      await executeQuery(
+        schema,
+        parse(
+          `
+            query {
+              uBaz {
+                ... on Foo {
+                  foo
+                }
+                ... on Bar {
+                  bar
+                }
+              }
+            }
+          `
+        )
+      );
+
+      expect(inf.fields).toMatchObject({
+        Foo: expect.arrayContaining(["foo"]),
+        Bar: expect.arrayContaining(["bar"])
+      });
+
+      // should not contain the union type as there cannot
+      // be a selection set for unions without a specific type
+      expect(Object.keys(inf.fields)).not.toContain("Baz");
+    });
+
+    test("unions with fragments", async () => {
+      await executeQuery(
+        schema,
+        parse(
+          `
+            query {
+              uBaz {
+                ...foo
+                ...bar
+              }
+            }
+            fragment foo on Foo {
+              foo
+            }
+            fragment bar on Bar {
+              bar
+            }
+          `
+        )
+      );
+
+      expect(inf.fields).toMatchObject({
+        Foo: expect.arrayContaining(["foo"]),
+        Bar: expect.arrayContaining(["bar"])
+      });
+    });
   });
 });
 
@@ -174,8 +301,4 @@ function executeQuery(
     return prepared;
   }
   return prepared.query(rootValue, contextValue, variableValues || {});
-}
-
-interface Resolver {
-  (parent: any, params: any, context: any, info: GraphQLJitResolveInfo): any;
 }

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -441,6 +441,34 @@ describe("GraphQLJitResolveInfo", () => {
       `);
     });
 
+    test("__typename", async () => {
+      const result = await executeQuery(
+        schema,
+        parse(`
+          query {
+            uBaz {
+              __typename
+              alias: __typename
+            }
+          }
+        `)
+      );
+      expect(result.errors).not.toBeDefined();
+      expect(inf.fieldExpansion).toMatchInlineSnapshot(`
+        Object {
+          "Bar": Object {
+            "__typename": true,
+          },
+          "Baz": Object {
+            "__typename": true,
+          },
+          "Foo": Object {
+            "__typename": true,
+          },
+        }
+      `);
+    });
+
     test("unions with fragments", async () => {
       const result = await executeQuery(
         schema,

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -921,6 +921,142 @@ describe("GraphQLJitResolveInfo", () => {
         }
       `);
     });
+
+    test("alias 1", async () => {
+      const doc = parse(`
+        query {
+          node(id: "tag:1") {
+            ... {
+              otherId: id
+            }
+            ... on Tag {
+              tagId: id,
+              tagName: name
+            }
+          }
+        }
+      `);
+      const result = await executeQuery(schema, doc);
+      const validationErrors = validate(schema, doc);
+      if (validationErrors.length > 0) {
+        console.error(validationErrors);
+      }
+      expect(validationErrors.length).toBe(0);
+      expect(result.errors).not.toBeDefined();
+      expect(infNode.fieldExpansion).toMatchInlineSnapshot(`
+        Object {
+          "Image": Object {
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+          },
+          "Media": Object {},
+          "Node": Object {
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+          },
+          "Tag": Object {
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "name": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+          },
+          "Video": Object {
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+          },
+        }
+      `);
+    });
+
+    test("aliases and __typename should not be included in resolveInfo", async () => {
+      const doc = parse(`
+        query {
+          node(id: "tag:1") {
+            __typename
+            ... {
+              __typename
+              otherId: id
+            }
+            ... on Tag {
+              tagId: id,
+              tagName: name
+            }
+            ... on DocumentElement {
+              __typename
+            }
+            ... on Media {
+              __typename
+              mediaTags: tags {
+                __typename
+                mediaTagName: name
+              }
+            }
+          }
+        }
+      `);
+      const result = await executeQuery(schema, doc);
+      const validationErrors = validate(schema, doc);
+      if (validationErrors.length > 0) {
+        console.error(validationErrors);
+      }
+      expect(validationErrors.length).toBe(0);
+      expect(result.errors).not.toBeDefined();
+      expect(infNode.fieldExpansion).toMatchInlineSnapshot(`
+        Object {
+          "Image": Object {
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "tags": Object {
+              "Tag": Object {
+                "name": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
+              },
+            },
+          },
+          "Media": Object {
+            "tags": Object {
+              "Tag": Object {
+                "name": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
+              },
+            },
+          },
+          "Node": Object {
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+          },
+          "Tag": Object {
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "name": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+          },
+          "Video": Object {
+            "id": Object {
+              Symbol(LeafFieldSymbol): true,
+            },
+            "tags": Object {
+              "Tag": Object {
+                "name": Object {
+                  Symbol(LeafFieldSymbol): true,
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
   });
 });
 

--- a/src/__tests__/union-interface.test.ts
+++ b/src/__tests__/union-interface.test.ts
@@ -37,7 +37,7 @@ function execute(
   root?: any,
   context?: any
 ) {
-  const { query }: any = compileQuery(schema, document, "");
+  const { query, errors }: any = compileQuery(schema, document, "");
   return query(root, context, {});
 }
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -42,8 +42,8 @@ import {
 import { GraphQLError as GraphqlJitError } from "./error";
 import { queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
-import { compileVariableParsing } from "./variables";
 import { createResolveInfoThunk } from "./resolve-info";
+import { compileVariableParsing } from "./variables";
 
 export interface CompilerOptions {
   customJSONSerializer: boolean;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -43,6 +43,7 @@ import { GraphQLError as GraphqlJitError } from "./error";
 import { queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
 import { compileVariableParsing } from "./variables";
+import { createResolveInfoThunk } from "./resolve-info";
 
 export interface CompilerOptions {
   customJSONSerializer: boolean;
@@ -947,21 +948,14 @@ function getExecutionInfo(
 
   context.dependencies.set(
     resolveInfoName,
-    (
-      rootValue: any,
-      variableValues: any,
-      path: ObjectPath
-    ): GraphQLResolveInfo => ({
-      fieldName,
-      fieldNodes,
-      returnType: fieldType,
-      parentType,
-      path,
+    createResolveInfoThunk({
       schema,
       fragments,
-      rootValue,
       operation,
-      variableValues
+      parentType,
+      fieldName,
+      fieldType,
+      fieldNodes
     })
   );
   return `${resolveInfoName}(${GLOBAL_ROOT_NAME}, ${GLOBAL_VARIABLES_NAME}, ${serializeResponsePath(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export {
   CompilerOptions,
   CompiledQuery
 } from "./execution";
+export { GraphQLJitResolveInfo } from "./resolve-info";

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -32,37 +32,49 @@ type Args4<T> = T extends (
     }
   : never;
 
-type Ret2<A, B, R> = (a: A) => (b: B) => R;
-type Ret3<A, B, C, R> = (a: A) => (b: B) => (c: C) => R;
-type Ret4<A, B, C, D, R> = (a: A) => (b: B) => (c: C) => (d: D) => R;
+function uncurry2<A, B, R>(fn: (a: A) => (b: B) => R) {
+  return (a: A, b: B) => fn(a)(b);
+}
 
-export function memoize2<T extends Fn>(fn: T) {
+function uncurry3<A, B, C, R>(fn: (a: A) => (b: B) => (c: C) => R) {
+  return (a: A, b: B, c: C) => fn(a)(b)(c);
+}
+
+function uncurry4<A, B, C, D, R>(
+  fn: (a: A) => (b: B) => (c: C) => (d: D) => R
+) {
+  return (a: A, b: B, c: C, d: D) => fn(a)(b)(c)(d);
+}
+
+export function memoize2<T extends Fn>(fn: T): T {
   type A = Args2<T>[0];
   type B = Args2<T>[1];
   type R = Args2<T>["return"];
 
-  return memoize((a: A) => memoize((b: B) => fn(a, b))) as Ret2<A, B, R>;
+  return uncurry2(memoize((a: A) => memoize((b: B) => fn(a, b)))) as T;
 }
 
-export function memoize3<T extends Fn>(fn: T) {
+export function memoize3<T extends Fn>(fn: T): T {
   type A = Args3<T>[0];
   type B = Args3<T>[1];
   type C = Args3<T>[2];
   type R = Args2<T>["return"];
 
-  return memoize((a: A) =>
-    memoize((b: B) => memoize((c: C) => fn(a, b, c)))
-  ) as Ret3<A, B, C, R>;
+  return uncurry3(
+    memoize((a: A) => memoize((b: B) => memoize((c: C) => fn(a, b, c))))
+  ) as T;
 }
 
-export function memoize4<T extends Fn>(fn: T) {
+export function memoize4<T extends Fn>(fn: T): T {
   type A = Args4<T>[0];
   type B = Args4<T>[1];
   type C = Args4<T>[2];
   type D = Args4<T>[3];
   type R = Args2<T>["return"];
 
-  return memoize((a: A) =>
-    memoize((b: B) => memoize((c: C) => memoize((d: D) => fn(a, b, c, d))))
-  ) as Ret4<A, B, C, D, R>;
+  return uncurry4(
+    memoize((a: A) =>
+      memoize((b: B) => memoize((c: C) => memoize((d: D) => fn(a, b, c, d))))
+    )
+  ) as T;
 }

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -1,0 +1,68 @@
+import memoize from "lodash.memoize";
+
+type Fn = (...args: any[]) => any;
+
+type Args2<T> = T extends (a: infer A, b: infer B) => infer R
+  ? {
+      0: A;
+      1: B;
+      return: R;
+    }
+  : never;
+type Args3<T> = T extends (a: infer A, b: infer B, c: infer C) => infer R
+  ? {
+      0: A;
+      1: B;
+      2: C;
+      return: R;
+    }
+  : never;
+type Args4<T> = T extends (
+  a: infer A,
+  b: infer B,
+  c: infer C,
+  d: infer D
+) => infer R
+  ? {
+      0: A;
+      1: B;
+      2: C;
+      3: D;
+      return: R;
+    }
+  : never;
+
+type Ret2<A, B, R> = (a: A) => (b: B) => R;
+type Ret3<A, B, C, R> = (a: A) => (b: B) => (c: C) => R;
+type Ret4<A, B, C, D, R> = (a: A) => (b: B) => (c: C) => (d: D) => R;
+
+export function memoize2<T extends Fn>(fn: T) {
+  type A = Args2<T>[0];
+  type B = Args2<T>[1];
+  type R = Args2<T>["return"];
+
+  return memoize((a: A) => memoize((b: B) => fn(a, b))) as Ret2<A, B, R>;
+}
+
+export function memoize3<T extends Fn>(fn: T) {
+  type A = Args3<T>[0];
+  type B = Args3<T>[1];
+  type C = Args3<T>[2];
+  type R = Args2<T>["return"];
+
+  return memoize((a: A) =>
+    memoize((b: B) => memoize((c: C) => fn(a, b, c)))
+  ) as Ret3<A, B, C, R>;
+}
+
+export function memoize4<T extends Fn>(fn: T) {
+  type A = Args4<T>[0];
+  type B = Args4<T>[1];
+  type C = Args4<T>[2];
+  type D = Args4<T>[3];
+  type R = Args2<T>["return"];
+
+  return memoize((a: A) =>
+    memoize((b: B) => memoize((c: C) => memoize((d: D) => fn(a, b, c, d))))
+  ) as Ret4<A, B, C, D, R>;
+}

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -8,21 +8,26 @@ import {
   GraphQLType,
   isListType,
   isScalarType,
-  isTypeSubTypeOf,
   SelectionNode,
-  SelectionSetNode
+  SelectionSetNode,
+  isOutputType,
+  isObjectType,
+  isInterfaceType,
+  isCompositeType,
+  GraphQLCompositeType
 } from "graphql";
 import { ObjectPath } from "./ast";
 
 export interface GraphQLJitResolveInfo extends GraphQLResolveInfo {
-  /**
-   * A list of field names requested at the current Object/List type
-   * It is null for leaf nodes. This is rather useful for lookaheads
-   * to construct the query to the backend in the resolver
-   */
-  fields: {
-    [returnType: string]: string[];
-  };
+  fieldExpansion: FieldExpansion;
+}
+
+export interface FieldExpansion {
+  [returnType: string]: TypeExpansion;
+}
+
+export interface TypeExpansion {
+  [fieldName: string]: FieldExpansion | true;
 }
 
 export function createResolveInfoThunk({
@@ -42,26 +47,12 @@ export function createResolveInfoThunk({
   fieldName: string;
   fieldNodes: FieldNode[];
 }) {
-  const fields: GraphQLJitResolveInfo["fields"] = {};
   const returnType = getEndReturnType(fieldType);
+  const fieldExpansion: FieldExpansion = {};
 
   if (returnType != null) {
-    const selections = getAllSelectionFieldNodes(
-      schema,
-      fieldNodes,
-      returnType,
-      fragments
-    );
-    for (const fieldType in selections) {
-      if (Object.prototype.hasOwnProperty.call(selections, fieldType)) {
-        // Get unique names of fields from the fieldNodes list for
-        // each return Type
-        const selectionFields: Set<string> = new Set(
-          selections[fieldType].map(fieldNode => fieldNode.name.value)
-        );
-
-        fields[fieldType] = [...selectionFields];
-      }
+    for (const fieldNode of fieldNodes) {
+      handleFieldNode(schema, fragments, returnType, fieldNode, fieldExpansion);
     }
   }
 
@@ -80,7 +71,7 @@ export function createResolveInfoThunk({
     rootValue,
     operation,
     variableValues,
-    fields
+    fieldExpansion
   });
 }
 
@@ -94,105 +85,176 @@ function getEndReturnType(fieldType: GraphQLOutputType): string | undefined {
   return fieldType.name;
 }
 
-type FieldNodesType = GraphQLResolveInfo["fieldNodes"];
 type FragmentsType = GraphQLResolveInfo["fragments"];
 
-interface SelectionFieldsCollector {
-  [fieldType: string]: FieldNode[];
-}
-
-function collectorSet(
-  collector: SelectionFieldsCollector,
-  fieldType: string,
-  fieldNode: FieldNode
-) {
-  if (!Object.prototype.hasOwnProperty.call(collector, fieldType)) {
-    collector[fieldType] = [];
-  }
-  collector[fieldType].push(fieldNode);
-}
-
-/**
- * Computes the list of selections for the current field by upwrapping
- * Inline fragments and Fragments
- */
-function getAllSelectionFieldNodes(
-  schema: GraphQLSchema,
-  fieldNodes: FieldNodesType,
-  defaultReturnType: string,
-  fragments: FragmentsType
-) {
-  const collector: SelectionFieldsCollector = {};
-
-  for (const fieldNode of fieldNodes) {
-    if (fieldNode.selectionSet) {
-      handleSelectionSet(
-        fragments,
-        defaultReturnType,
-        fieldNode.selectionSet,
-        collector
-      );
-    }
-  }
-
-  // normalize the fields and duplicate it to all sub-types
-  const fieldTypes = Object.keys(collector);
-  for (let i = 0; i < fieldTypes.length; i++) {
-    for (let j = i + 1; j < fieldTypes.length; j++) {
-      const iType = schema.getType(fieldTypes[i]);
-      const jType = schema.getType(fieldTypes[j]);
-      if (iType && jType) {
-        if (isTypeSubTypeOf(schema, iType, jType)) {
-          collector[fieldTypes[i]].push(...collector[fieldTypes[j]]);
-        } else if (isTypeSubTypeOf(schema, jType, iType)) {
-          collector[fieldTypes[j]].push(...collector[fieldTypes[i]]);
-        }
-      }
-    }
-  }
-
-  return collector;
-}
-
 function handleSelectionSet(
+  schema: GraphQLSchema,
   fragments: FragmentsType,
-  returnType: string,
+  possibleTypes: string[],
   selectionSet: SelectionSetNode,
-  collector: SelectionFieldsCollector
+  fieldExpansion: FieldExpansion
 ) {
   for (const selection of selectionSet.selections) {
-    handleSelection(fragments, returnType, selection, collector);
+    handleSelection(
+      schema,
+      fragments,
+      possibleTypes,
+      selection,
+      fieldExpansion
+    );
+  }
+}
+
+function handleFieldNode(
+  schema: GraphQLSchema,
+  fragments: FragmentsType,
+  returnType: string,
+  node: FieldNode,
+  fieldExpansion: FieldExpansion
+) {
+  if (node.selectionSet != null) {
+    const possibleTypes = getPossibleTypes(schema, returnType);
+    for (const typ of possibleTypes) {
+      if (!Object.prototype.hasOwnProperty.call(fieldExpansion, typ)) {
+        fieldExpansion[typ] = {};
+      }
+    }
+    handleSelectionSet(
+      schema,
+      fragments,
+      possibleTypes,
+      node.selectionSet,
+      fieldExpansion
+    );
+  } else {
+    throw new Error("should not be called");
   }
 }
 
 function handleSelection(
+  schema: GraphQLSchema,
   fragments: FragmentsType,
-  returnType: string,
+  possibleTypes: string[],
   node: SelectionNode,
-  collector: SelectionFieldsCollector
+  fieldExpansion: FieldExpansion
 ) {
   switch (node.kind) {
     case "Field":
-      collectorSet(collector, returnType, node);
+      if (node.selectionSet != null) {
+        const returnType = getReturnType(
+          schema,
+          possibleTypes[0],
+          node.name.value
+        );
+        const nextFieldExpansion: FieldExpansion = {};
+        handleFieldNode(
+          schema,
+          fragments,
+          returnType,
+          node,
+          nextFieldExpansion
+        );
+        for (const typ of possibleTypes) {
+          fieldExpansion[typ][node.name.value] = nextFieldExpansion;
+        }
+      } else {
+        for (const typ of possibleTypes) {
+          fieldExpansion[typ][node.name.value] = true;
+        }
+      }
       break;
 
     case "InlineFragment":
       handleSelectionSet(
+        schema,
         fragments,
-        node.typeCondition == null ? returnType : node.typeCondition.name.value,
+        node.typeCondition == null
+          ? possibleTypes
+          : [node.typeCondition.name.value],
         node.selectionSet,
-        collector
+        fieldExpansion
       );
       break;
 
     case "FragmentSpread":
       const fragment = fragments[node.name.value];
       handleSelectionSet(
+        schema,
         fragments,
-        fragment.typeCondition.name.value,
+        [fragment.typeCondition.name.value],
         fragment.selectionSet,
-        collector
+        fieldExpansion
       );
       break;
   }
+}
+
+function getReturnType(
+  schema: GraphQLSchema,
+  parentType: string,
+  fieldName: string
+): string {
+  const typ = schema.getType(parentType);
+  if (typ == null) {
+    throw new Error(`Type not found in schema ${parentType}`);
+  }
+  if (!(isInterfaceType(typ) || isObjectType(typ))) {
+    throw new Error(
+      `Field ${fieldName} selected for ${parentType} - not objectlike`
+    );
+  }
+  const fields = typ.getFields();
+  if (!Object.prototype.hasOwnProperty.call(fields, fieldName)) {
+    throw new Error(`Field ${fieldName} does not exist in ${parentType}`);
+  }
+  const outputType = fields[fieldName].type;
+  if (isListType(outputType)) {
+    return resolveListType(outputType);
+  }
+  return outputType.name;
+}
+
+function getPossibleTypes(
+  schema: GraphQLSchema,
+  currentType: string
+): string[] {
+  const typ = schema.getType(currentType);
+  if (typ == null) {
+    throw new Error(`Type not found in schema "${currentType}"`);
+  }
+  if (!isOutputType(typ)) {
+    throw new Error(`Expected GraphQL Output type. Got ${currentType}`);
+  }
+
+  const resolvedType = resolveOutputFieldType(typ);
+
+  if (isObjectType(resolvedType)) {
+    return [resolvedType.name];
+  }
+
+  const possibleTypes = schema.getPossibleTypes(resolvedType);
+  const fieldTypes: string[] = [];
+  if (isInterfaceType(resolvedType)) {
+    fieldTypes.push(resolvedType.name);
+  }
+  return [...fieldTypes, ...possibleTypes.map(objectType => objectType.name)];
+}
+
+function resolveOutputFieldType(typ: GraphQLOutputType): GraphQLCompositeType {
+  if (isListType(typ)) {
+    return resolveOutputFieldType(typ.ofType);
+  }
+  if (!isCompositeType(typ)) {
+    throw new Error(`Expected a Composite Type. Got ${typ.name}`);
+  }
+
+  return typ;
+}
+
+function resolveListType(typ: GraphQLType): string {
+  if (isListType(typ)) {
+    return resolveListType(typ.ofType);
+  }
+
+  return typ.name;
 }

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -3,23 +3,24 @@ import {
   FieldNode,
   GraphQLCompositeType,
   GraphQLError,
+  GraphQLInterfaceType,
   GraphQLNamedType,
   GraphQLObjectType,
   GraphQLOutputType,
   GraphQLResolveInfo,
   GraphQLSchema,
   isCompositeType,
-  isInterfaceType,
   isListType,
   isNonNullType,
   isObjectType,
-  SelectionNode,
+  isUnionType,
   SelectionSetNode
 } from "graphql";
+import deepMerge from "lodash.merge";
 import { ObjectPath } from "./ast";
 
 export interface GraphQLJitResolveInfo extends GraphQLResolveInfo {
-  fieldExpansion: FieldExpansion;
+  fieldExpansion: FieldExpansion | true;
 }
 
 export interface FieldExpansion {
@@ -61,9 +62,13 @@ export function createResolveInfoThunk({
   // Result
   const fieldExpansion: FieldExpansion = {};
 
+  const expander = new Expander(schema, fragments);
   if (returnType != null) {
     for (const fieldNode of fieldNodes) {
-      handleFieldNode(schema, fragments, returnType, fieldNode, fieldExpansion);
+      deepMerge(
+        fieldExpansion,
+        expander.expandFieldNode(fieldNode, returnType)
+      );
     }
   }
 
@@ -89,147 +94,116 @@ export function createResolveInfoThunk({
 type FragmentsType = GraphQLResolveInfo["fragments"];
 type GraphQLNamedOutputType = GraphQLNamedType & GraphQLOutputType;
 
-function handleSelectionSet(
-  schema: GraphQLSchema,
-  fragments: FragmentsType,
-  possibleTypes: GraphQLCompositeType[],
-  selectionSet: SelectionSetNode,
-  fieldExpansion: FieldExpansion
-) {
-  for (const selection of selectionSet.selections) {
-    handleSelection(
-      schema,
-      fragments,
-      possibleTypes,
-      selection,
-      fieldExpansion
-    );
-  }
-}
+class Expander {
+  constructor(
+    private readonly schema: Readonly<GraphQLSchema>,
+    private readonly fragments: Readonly<FragmentsType>
+  ) {}
 
-/**
- * Compute a list of possible Types from the returnType of the field and
- * build the TypeExpansion object for the Field. Pass it down to other
- * handlers to populate.
- */
-function handleFieldNode(
-  schema: GraphQLSchema,
-  fragments: FragmentsType,
-  returnType: GraphQLOutputType,
-  node: FieldNode,
-  fieldExpansion: FieldExpansion
-) {
-  if (node.selectionSet != null) {
-    const resolvedType = resolveEndType(returnType);
-    const possibleTypes = getPossibleTypes(
-      schema,
-      // if there is a selectionSet, the resolved type must be a composite type
-      resolvedType as GraphQLCompositeType
-    );
+  public expandFieldNode(
+    node: FieldNode,
+    fieldType: GraphQLOutputType
+  ): FieldExpansion | true {
+    if (node.selectionSet == null) {
+      return true;
+    }
 
-    for (const typ of possibleTypes) {
-      if (!Object.prototype.hasOwnProperty.call(fieldExpansion, typ.name)) {
-        fieldExpansion[typ.name] = {};
+    // there is a selectionSet which makes the fieldType a CompositeType
+    const typ = resolveEndType(fieldType) as GraphQLCompositeType;
+    const possibleTypes = this.getPossibleTypes(typ);
+
+    const fieldExpansion: FieldExpansion = {};
+    for (const possibleType of possibleTypes) {
+      if (!isUnionType(possibleType)) {
+        fieldExpansion[possibleType.name] = this.expandFieldNodeType(
+          possibleType,
+          node.selectionSet
+        );
       }
     }
 
-    handleSelectionSet(
-      schema,
-      fragments,
-      possibleTypes,
-      node.selectionSet,
-      fieldExpansion
-    );
+    return fieldExpansion;
   }
-}
 
-/**
- * Handle different kinds of selection nodes accordingly.
- *
- * For a field, add the field to the TypeExpansion. Create and link
- * the next FieldExpansion object to be handled recursively
- *
- */
-function handleSelection(
-  schema: GraphQLSchema,
-  fragments: FragmentsType,
-  possibleTypes: GraphQLCompositeType[],
-  node: SelectionNode,
-  fieldExpansion: FieldExpansion
-) {
-  switch (node.kind) {
-    case "Field":
-      if (node.selectionSet != null) {
-        const returnType = getReturnType(possibleTypes[0], node.name.value);
-        const nextFieldExpansion: FieldExpansion = {};
-        handleFieldNode(
-          schema,
-          fragments,
-          returnType,
-          node,
-          nextFieldExpansion
-        );
-        for (const typ of possibleTypes) {
-          fieldExpansion[typ.name][node.name.value] = nextFieldExpansion;
+  public expandFieldNodeType(
+    parentType: GraphQLCompositeType,
+    selectionSet: SelectionSetNode,
+    level = 0
+  ): TypeExpansion {
+    const typeExpansion: TypeExpansion = {};
+
+    for (const selection of selectionSet.selections) {
+      if (selection.kind === "Field") {
+        if (
+          !isUnionType(parentType) &&
+          hasField(parentType, selection.name.value)
+        ) {
+          typeExpansion[selection.name.value] = this.expandFieldNode(
+            selection,
+            getReturnType(parentType, selection.name.value)
+          );
         }
       } else {
-        for (const typ of possibleTypes) {
-          fieldExpansion[typ.name][node.name.value] = true;
-        }
-      }
-      break;
-
-    case "InlineFragment":
-      {
-        let nextPossibleTypes = possibleTypes;
-        if (node.typeCondition != null) {
-          const typeConditionType = schema.getType(
-            node.typeCondition.name.value
-          );
-          if (typeConditionType == null) {
-            throw new GraphQLError(
-              `Invalid InlineFragment: Type "${
-                node.typeCondition.name.value
-              }" does not exist in schema.`
-            );
-          }
-          // here we are inside a fragment and it's possible only for Composite Types
-          nextPossibleTypes = [typeConditionType as GraphQLCompositeType];
-        }
-
-        handleSelectionSet(
-          schema,
-          fragments,
-          nextPossibleTypes,
-          node.selectionSet,
-          fieldExpansion
+        const selectionSet =
+          selection.kind === "InlineFragment"
+            ? selection.selectionSet
+            : this.fragments[selection.name.value].selectionSet;
+        deepMerge(
+          typeExpansion,
+          this.expandFieldNodeType(parentType, selectionSet, level + 1)
         );
       }
-      break;
+    }
 
-    case "FragmentSpread":
-      {
-        const fragment = fragments[node.name.value];
-        const typeConditionType = schema.getType(
-          fragment.typeCondition.name.value
-        );
-        if (typeConditionType == null) {
-          throw new GraphQLError(
-            `Invalid Fragment: Type "${
-              fragment.typeCondition.name.value
-            }" does not exist in schema.`
-          );
+    return typeExpansion;
+  }
+
+  /**
+   * Returns a list of Possible types that one can get to from the
+   * resolvedType. As an analogy, these are the same types that one
+   * can use in a fragment's typeCondition.
+   *
+   * Note: This is different from schema.getPossibleTypes() that this
+   * returns all possible types and not just the ones from the type definition.
+   *
+   * Example:
+   * interface Node {
+   *   id: ID!
+   * }
+   * type User implements Node {
+   *   id: ID!
+   *   name: String
+   * }
+   * type Article implements Node {
+   *   id: ID!
+   *   title: String
+   * }
+   * union Card = User | Article
+   *
+   * - schema.getPossibleTypes(Card) would give [User, Article]
+   * - This function getPossibleTypes(schema, Card) would give [User, Article, Node]
+   *
+   */
+  public getPossibleTypes(compositeType: GraphQLCompositeType) {
+    if (isObjectType(compositeType)) {
+      return [compositeType];
+    }
+
+    const possibleTypes: GraphQLCompositeType[] = [];
+    const types = this.schema.getTypeMap();
+    for (const typeName in types) {
+      if (Object.prototype.hasOwnProperty.call(types, typeName)) {
+        const typ = types[typeName];
+        if (
+          isCompositeType(typ) &&
+          doTypesOverlap(this.schema, typ, compositeType)
+        ) {
+          possibleTypes.push(typ);
         }
-
-        handleSelectionSet(
-          schema,
-          fragments,
-          [typeConditionType as GraphQLCompositeType],
-          fragment.selectionSet,
-          fieldExpansion
-        );
       }
-      break;
+    }
+
+    return possibleTypes;
   }
 }
 
@@ -241,15 +215,9 @@ function handleSelection(
  * and list types. Check `resolveEndType`
  */
 function getReturnType(
-  parentType: GraphQLCompositeType,
+  parentType: GraphQLInterfaceType | GraphQLObjectType,
   fieldName: string
 ): GraphQLNamedOutputType {
-  if (!(isInterfaceType(parentType) || isObjectType(parentType))) {
-    throw new GraphQLError(
-      `Invalid selection: Field "${fieldName}" for type "${parentType.name}"`
-    );
-  }
-
   const fields = parentType.getFields();
   if (!Object.prototype.hasOwnProperty.call(fields, fieldName)) {
     throw new GraphQLError(
@@ -262,54 +230,6 @@ function getReturnType(
 }
 
 /**
- * Returns a list of Possible types that one can get to from the
- * resolvedType. As an analogy, these are the same types that one
- * can use in a fragment's typeCondition.
- *
- * Note: This is different from schema.getPossibleTypes() that this
- * returns all possible types and not just the ones from the type definition.
- *
- * Example:
- * interface Node {
- *   id: ID!
- * }
- * type User implements Node {
- *   id: ID!
- *   name: String
- * }
- * type Article implements Node {
- *   id: ID!
- *   title: String
- * }
- * union Card = User | Article
- *
- * - schema.getPossibleTypes(Card) would give [User, Article]
- * - This function getPossibleTypes(schema, Card) would give [User, Article, Node]
- *
- */
-function getPossibleTypes(
-  schema: GraphQLSchema,
-  resolvedType: GraphQLCompositeType
-): GraphQLCompositeType[] {
-  if (isObjectType(resolvedType)) {
-    return [resolvedType];
-  }
-
-  const possibleTypes: GraphQLCompositeType[] = [];
-  const types = schema.getTypeMap();
-  for (const typeName in types) {
-    if (Object.prototype.hasOwnProperty.call(types, typeName)) {
-      const typ = types[typeName];
-      if (isCompositeType(typ) && doTypesOverlap(schema, typ, resolvedType)) {
-        possibleTypes.push(typ);
-      }
-    }
-  }
-
-  return possibleTypes;
-}
-
-/**
  * Resolve to the end type of the Output type unwrapping non-null types and lists
  */
 function resolveEndType(typ: GraphQLOutputType): GraphQLNamedOutputType {
@@ -317,4 +237,11 @@ function resolveEndType(typ: GraphQLOutputType): GraphQLNamedOutputType {
     return resolveEndType(typ.ofType);
   }
   return typ;
+}
+
+function hasField(
+  typ: GraphQLInterfaceType | GraphQLObjectType,
+  fieldName: string
+) {
+  return Object.prototype.hasOwnProperty.call(typ.getFields(), fieldName);
 }

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -1,20 +1,20 @@
 import {
+  doTypesOverlap,
   FieldNode,
+  GraphQLCompositeType,
   GraphQLObjectType,
   GraphQLOutputType,
   GraphQLResolveInfo,
   GraphQLSchema,
   GraphQLType,
-  isListType,
-  SelectionNode,
-  SelectionSetNode,
-  isOutputType,
-  isObjectType,
-  isInterfaceType,
   isCompositeType,
-  GraphQLCompositeType,
+  isInterfaceType,
+  isListType,
   isNonNullType,
-  doTypesOverlap
+  isObjectType,
+  isOutputType,
+  SelectionNode,
+  SelectionSetNode
 } from "graphql";
 import { ObjectPath } from "./ast";
 
@@ -219,10 +219,12 @@ function getPossibleTypes(
 
   const possibleTypes: string[] = [];
   const types = schema.getTypeMap();
-  for (let typeName in types) {
-    const typ = types[typeName];
-    if (isCompositeType(typ) && doTypesOverlap(schema, typ, resolvedType)) {
-      possibleTypes.push(typ.name);
+  for (const typeName in types) {
+    if (Object.prototype.hasOwnProperty.call(types, typeName)) {
+      const typ = types[typeName];
+      if (isCompositeType(typ) && doTypesOverlap(schema, typ, resolvedType)) {
+        possibleTypes.push(typ.name);
+      }
     }
   }
 

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -1,0 +1,201 @@
+import {
+  GraphQLResolveInfo,
+  FieldNode,
+  SelectionSetNode,
+  SelectionNode,
+  GraphQLObjectType,
+  GraphQLOutputType,
+  isScalarType,
+  isListType,
+  GraphQLList,
+  GraphQLType,
+  isTypeSubTypeOf,
+  GraphQLSchema
+} from "graphql";
+import { ObjectPath } from "./ast";
+
+export interface GraphQLJitResolveInfo extends GraphQLResolveInfo {
+  /**
+   * A list of field names requested at the current Object/List type
+   * It is null for leaf nodes. This is rather useful for lookaheads
+   * to construct the query to the backend in the resolver
+   */
+  fields: {
+    [returnType: string]: string[];
+  };
+}
+
+export function createResolveInfoThunk({
+  schema,
+  fragments,
+  operation,
+  parentType,
+  fieldName,
+  fieldType,
+  fieldNodes
+}: {
+  schema: GraphQLResolveInfo["schema"];
+  fragments: GraphQLResolveInfo["fragments"];
+  operation: GraphQLResolveInfo["operation"];
+  parentType: GraphQLObjectType;
+  fieldType: GraphQLOutputType;
+  fieldName: string;
+  fieldNodes: FieldNode[];
+}) {
+  let fields: GraphQLJitResolveInfo["fields"] = {};
+  const returnType = getEndReturnType(fieldType);
+
+  if (returnType != null) {
+    const selections = getAllSelectionFieldNodes(
+      schema,
+      fieldNodes,
+      returnType,
+      fragments
+    );
+    for (let fieldType in selections) {
+      if (Object.prototype.hasOwnProperty.call(selections, fieldType)) {
+        // Get unique names of fields from the fieldNodes list for
+        // each return Type
+        const selectionFields: Set<string> = new Set(
+          selections[fieldType].map(fieldNode => fieldNode.name.value)
+        );
+
+        fields[fieldType] = [...selectionFields];
+      }
+    }
+  }
+
+  return (
+    rootValue: any,
+    variableValues: any,
+    path: ObjectPath
+  ): GraphQLJitResolveInfo => ({
+    fieldName,
+    fieldNodes,
+    returnType: fieldType,
+    parentType,
+    path,
+    schema,
+    fragments,
+    rootValue,
+    operation,
+    variableValues,
+    fields
+  });
+}
+
+function getEndReturnType(fieldType: GraphQLOutputType): string | undefined {
+  if (isScalarType(fieldType)) {
+    return;
+  }
+  if (isListType(fieldType)) {
+    return getEndReturnType(fieldType.ofType);
+  }
+  return fieldType.name;
+}
+
+type FieldNodesType = GraphQLResolveInfo["fieldNodes"];
+type FragmentsType = GraphQLResolveInfo["fragments"];
+
+interface SelectionFieldsCollector {
+  [fieldType: string]: FieldNode[];
+}
+
+function collectorSet(
+  collector: SelectionFieldsCollector,
+  fieldType: string,
+  fieldNode: FieldNode
+) {
+  if (!Object.prototype.hasOwnProperty.call(collector, fieldType)) {
+    collector[fieldType] = [];
+  }
+  collector[fieldType].push(fieldNode);
+}
+
+/**
+ * Computes the list of selections for the current field by upwrapping
+ * Inline fragments and Fragments
+ */
+function getAllSelectionFieldNodes(
+  schema: GraphQLSchema,
+  fieldNodes: FieldNodesType,
+  defaultReturnType: string,
+  fragments: FragmentsType
+) {
+  const collector: SelectionFieldsCollector = {};
+
+  for (const fieldNode of fieldNodes) {
+    if (fieldNode.selectionSet) {
+      handleSelectionSet(
+        fragments,
+        defaultReturnType,
+        fieldNode.selectionSet,
+        collector
+      );
+    }
+  }
+
+  // normalize the fields and duplicate it to all sub-types
+  const fieldTypes = Object.keys(collector);
+  for (let i = 0; i < fieldTypes.length; i++) {
+    for (let j = i + 1; j < fieldTypes.length; j++) {
+      const iType = schema.getType(fieldTypes[i]);
+      const jType = schema.getType(fieldTypes[j]);
+      if (iType && jType) {
+        if (isTypeSubTypeOf(schema, iType, jType)) {
+          collector[fieldTypes[i]].push(...collector[fieldTypes[j]]);
+        } else if (isTypeSubTypeOf(schema, jType, iType)) {
+          collector[fieldTypes[j]].push(...collector[fieldTypes[i]]);
+        }
+      }
+    }
+  }
+
+  return collector;
+}
+
+function handleSelectionSet(
+  fragments: FragmentsType,
+  returnType: string,
+  selectionSet: SelectionSetNode,
+  collector: SelectionFieldsCollector
+) {
+  for (const selection of selectionSet.selections) {
+    handleSelection(fragments, returnType, selection, collector);
+  }
+}
+
+function handleSelection(
+  fragments: FragmentsType,
+  returnType: string,
+  node: SelectionNode,
+  collector: SelectionFieldsCollector
+) {
+  switch (node.kind) {
+    case "Field":
+      collectorSet(collector, returnType, node);
+      break;
+
+    case "InlineFragment":
+      if (node.typeCondition == null) {
+        throw new Error(`TypeCondition is undefined for ${node}`);
+      }
+      handleSelectionSet(
+        fragments,
+        node.typeCondition.name.value,
+        node.selectionSet,
+        collector
+      );
+      break;
+
+    case "FragmentSpread":
+      const fragment = fragments[node.name.value];
+      handleSelectionSet(
+        fragments,
+        fragment.typeCondition.name.value,
+        fragment.selectionSet,
+        collector
+      );
+      break;
+  }
+}

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -110,8 +110,7 @@ function handleFieldNode(
     const possibleTypes = getPossibleTypes(
       schema,
       // if there is a selectionSet, the resolved type must be a composite type
-      resolvedType as GraphQLCompositeType,
-      node.name.value
+      resolvedType as GraphQLCompositeType
     );
 
     for (const typ of possibleTypes) {
@@ -241,9 +240,7 @@ function getReturnType(
 
 function getPossibleTypes(
   schema: GraphQLSchema,
-  resolvedType: GraphQLCompositeType,
-  // this is only used for errors
-  fieldName: string
+  resolvedType: GraphQLCompositeType
 ): GraphQLCompositeType[] {
   if (isObjectType(resolvedType)) {
     return [resolvedType];

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -1,16 +1,16 @@
 import {
-  GraphQLResolveInfo,
   FieldNode,
-  SelectionSetNode,
-  SelectionNode,
+  GraphQLList,
   GraphQLObjectType,
   GraphQLOutputType,
-  isScalarType,
-  isListType,
-  GraphQLList,
+  GraphQLResolveInfo,
+  GraphQLSchema,
   GraphQLType,
+  isListType,
+  isScalarType,
   isTypeSubTypeOf,
-  GraphQLSchema
+  SelectionNode,
+  SelectionSetNode
 } from "graphql";
 import { ObjectPath } from "./ast";
 
@@ -42,7 +42,7 @@ export function createResolveInfoThunk({
   fieldName: string;
   fieldNodes: FieldNode[];
 }) {
-  let fields: GraphQLJitResolveInfo["fields"] = {};
+  const fields: GraphQLJitResolveInfo["fields"] = {};
   const returnType = getEndReturnType(fieldType);
 
   if (returnType != null) {
@@ -52,7 +52,7 @@ export function createResolveInfoThunk({
       returnType,
       fragments
     );
-    for (let fieldType in selections) {
+    for (const fieldType in selections) {
       if (Object.prototype.hasOwnProperty.call(selections, fieldType)) {
         // Get unique names of fields from the fieldNodes list for
         // each return Type

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -8,13 +8,11 @@ import {
   GraphQLOutputType,
   GraphQLResolveInfo,
   GraphQLSchema,
-  GraphQLType,
   isCompositeType,
   isInterfaceType,
   isListType,
   isNonNullType,
   isObjectType,
-  isOutputType,
   SelectionNode,
   SelectionSetNode
 } from "graphql";

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -177,12 +177,9 @@ function handleSelection(
       break;
 
     case "InlineFragment":
-      if (node.typeCondition == null) {
-        throw new Error(`TypeCondition is undefined for ${node}`);
-      }
       handleSelectionSet(
         fragments,
-        node.typeCondition.name.value,
+        node.typeCondition == null ? returnType : node.typeCondition.name.value,
         node.selectionSet,
         collector
       );

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -230,7 +230,7 @@ function getReturnType(
   const fields = parentType.getFields();
   if (!Object.prototype.hasOwnProperty.call(fields, fieldName)) {
     throw new GraphQLError(
-      `Field "${fieldName}" does not exist in "${parentType}"`
+      `Field "${fieldName}" does not exist in "${parentType.name}"`
     );
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -362,6 +362,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.1.tgz#fcaa655260285b8061850789f8268c51a4ec8ee1"
   integrity sha512-NVQEMviDWjuen3UW+mU1J6fZ0WhOfG1yRce/2OTcbaz+fgmTw2cahx6N2wh0Yl+a+hg2UZj/oElZmtULWyGIsA==
 
+"@types/lodash.memoize@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
+  integrity sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.merge@^4.6.6":
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.6.tgz#b84b403c1d31bc42d51772d1cd5557fa008cd3d6"
@@ -2785,6 +2792,11 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
 lodash.merge@^4.6.1:
   version "4.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,6 +376,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.mergewith@^4.6.6":
+  version "4.6.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"
+  integrity sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.117"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.117.tgz#695a7f514182771a1e0f4345d189052ee33c8778"
@@ -2802,6 +2809,11 @@ lodash.merge@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
   integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
+
+lodash.mergewith@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+  integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,6 +494,25 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+apollo-link@^1.2.3:
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.11.tgz#493293b747ad3237114ccd22e9f559e5e24a194d"
+  integrity sha512-PQvRCg13VduLy3X/0L79M6uOpTh5iHdxnxYuo8yL7sJlWybKRJwsv4IcRBJpMFbChOOaHY7Og9wgPo6DLKDKDA==
+  dependencies:
+    apollo-utilities "^1.2.1"
+    ts-invariant "^0.3.2"
+    tslib "^1.9.3"
+    zen-observable-ts "^0.8.18"
+
+apollo-utilities@^1.0.1, apollo-utilities@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.2.1.tgz#1c3a1ebf5607d7c8efe7636daaf58e7463b41b3c"
+  integrity sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==
+  dependencies:
+    fast-json-stable-stringify "^2.0.0"
+    ts-invariant "^0.2.1"
+    tslib "^1.9.3"
+
 append-transform@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
@@ -1170,6 +1189,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+deprecated-decorator@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
+  integrity sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -1623,6 +1647,17 @@ graceful-fs@^4.1.15:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graphql-tools@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.4.tgz#ca08a63454221fdde825fe45fbd315eb2a6d566b"
+  integrity sha512-chF12etTIGVVGy3fCTJ1ivJX2KB7OSG4c6UOJQuqOHCmBQwTyNgCDuejZKvpYxNZiEx7bwIjrodDgDe9RIkjlw==
+  dependencies:
+    apollo-link "^1.2.3"
+    apollo-utilities "^1.0.1"
+    deprecated-decorator "^0.1.6"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
 
 graphql@^14.2.1:
   version "14.2.1"
@@ -2127,7 +2162,7 @@ istanbul-reports@^2.1.1:
   dependencies:
     handlebars "^4.1.0"
 
-iterall@^1.2.2:
+iterall@^1.1.3, iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
@@ -4147,6 +4182,20 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
+ts-invariant@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.2.1.tgz#3d587f9d6e3bded97bf9ec17951dd9814d5a9d3f"
+  integrity sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==
+  dependencies:
+    tslib "^1.9.3"
+
+ts-invariant@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.3.3.tgz#b5742b1885ecf9e29c31a750307480f045ec0b16"
+  integrity sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==
+  dependencies:
+    tslib "^1.9.3"
+
 ts-jest@^24.0.2:
   version "24.0.2"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
@@ -4173,7 +4222,7 @@ ts-node@^8.0.3:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -4303,7 +4352,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.3.2:
+uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -4504,3 +4553,16 @@ yup@^0.26.10:
     property-expr "^1.5.0"
     synchronous-promise "^2.0.5"
     toposort "^2.0.2"
+
+zen-observable-ts@^0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz#ade44b1060cc4a800627856ec10b9c67f5f639c8"
+  integrity sha512-q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==
+  dependencies:
+    tslib "^1.9.3"
+    zen-observable "^0.8.0"
+
+zen-observable@^0.8.0:
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.14.tgz#d33058359d335bc0db1f0af66158b32872af3bf7"
+  integrity sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==


### PR DESCRIPTION
The PR computes a representation of the fields in the Query to a tree form with all the fragments expanded. This is done at the compilation time and this info is useful at runtime to get the fields requested for a node in the graph. 
Shape of the result:

```ts
interface GraphQLJitResolveInfo extends GraphQLResolveInfo {
  fieldExpansion: FieldExpansion;
}
interface FieldExpansion {
  [returnType: string]: TypeExpansion
}
interface TypeExpansion {
  [fieldName: string]: FieldExpansion | { [LeafField]: true }
}
```

This is a helper for quick access to the list of fields selected at the current level. This is useful for transformations into queries to corresponding backends that can accept a list of fields for optimizing the amount of data and other computations.

Example:

```graphql
type Query {
  iBar: IBar
}
interface IBar {
  id: ID!
  title: String
}
type Bar1 implements IBar {
  id: ID!
  title: String
  b1: Int!
}
type Bar2 implements IBar {
  id: ID!
  title: String
  b2: Boolean!
}
```

and the query

```graphql
query {
  iBar {
    id
    title
    ... on Bar1 {
      b1
    }
    ... on Bar2 {
      b2
    }
  }
}
```

the `resolveInfo` at `iBar` would contain the following `fieldExpansion`: 

```
Object {
  "Bar1": Object {
    "b1": true,
    "id": true,
    "title": true,
  },
  "Bar2": Object {
    "b2": true,
    "id": true,
    "title": true,
  },
  "IBar": Object {
    "id": true,
    "title": true,
  },
}
```

### Advantages

This way, at runtime, we do get a list of fields that we can use to query the provider of `iBar` in the above example and it saves us in the following way -

1. response time of Provider
1. amount of data transfer
1. Deserialization time (say, JSON.parse time) - which are cpu bound.
