### PR TITLE
reexport types from resolve-info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,10 @@ export {
   CompilerOptions,
   CompiledQuery
 } from "./execution";
-export { GraphQLJitResolveInfo } from "./resolve-info";
+
+export {
+  GraphQLJitResolveInfo,
+  FieldExpansion,
+  LeafField,
+  TypeExpansion
+} from "./resolve-info";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,6 @@ export {
   GraphQLJitResolveInfo,
   FieldExpansion,
   LeafField,
-  TypeExpansion
+  TypeExpansion,
+  isLeafField
 } from "./resolve-info";


### PR DESCRIPTION
For cases where you look-ahead two or three levels deep it's useful to have this to typecast.

+ `(info.fieldExpansion as FieldExpansion)["Foo"]`
+ `isLeafField(fieldExpansion)`
