### PR TITLE
Move to a resolveInfo hook model.

### DIFF
--- a/src/__tests__/execution.test.ts
+++ b/src/__tests__/execution.test.ts
@@ -273,18 +273,20 @@ describe("Execute: Handles basic execution tasks", () => {
 
     executeQuery(schema, ast, rootValue, null, { var: "abc" });
 
-    expect(Object.keys(info)).toEqual([
-      "fieldName",
-      "fieldNodes",
-      "returnType",
-      "parentType",
-      "path",
-      "schema",
-      "fragments",
-      "rootValue",
-      "operation",
-      "variableValues"
-    ]);
+    expect(Object.keys(info).sort()).toEqual(
+      [
+        "fieldName",
+        "fieldNodes",
+        "returnType",
+        "parentType",
+        "path",
+        "schema",
+        "fragments",
+        "rootValue",
+        "operation",
+        "variableValues"
+      ].sort()
+    );
     expect(info.fieldName).toEqual("test");
     expect(info.fieldNodes).toHaveLength(1);
     expect(info.fieldNodes[0]).toEqual(

--- a/src/__tests__/execution.test.ts
+++ b/src/__tests__/execution.test.ts
@@ -152,6 +152,22 @@ describe("Execute: Handles basic execution tasks", () => {
 
     expect(() => executeQuery(schema)).toThrow("Must provide document");
   });
+  test("throws if no resolve info enricher is not a function", async () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: "Type",
+        fields: {
+          a: { type: GraphQLString }
+        }
+      })
+    });
+
+    expect(() =>
+      compileQuery(schema, parse("{ field }"), "", {
+        resolverInfoEnricher: "bad" as any
+      })
+    ).toThrow("resolverInfoEnricher must be a function");
+  });
 
   test("throws if no schema is provided", async () => {
     expect(() =>
@@ -267,8 +283,7 @@ describe("Execute: Handles basic execution tasks", () => {
       "fragments",
       "rootValue",
       "operation",
-      "variableValues",
-      "fieldExpansion"
+      "variableValues"
     ]);
     expect(info.fieldName).toEqual("test");
     expect(info.fieldNodes).toHaveLength(1);

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -1,6 +1,7 @@
 import { GraphQLSchema, DocumentNode, parse, validate } from "graphql";
 import { compileQuery, isCompiledQuery } from "../execution";
 import { makeExecutableSchema } from "graphql-tools";
+import { fieldExpansionEnricher } from "../resolve-info";
 
 describe("GraphQLJitResolveInfo", () => {
   describe("simple types", () => {
@@ -1071,7 +1072,8 @@ function executeQuery(
   const prepared: any = compileQuery(
     schema as any,
     document as any,
-    operationName || ""
+    operationName || "",
+    { resolverInfoEnricher: fieldExpansionEnricher }
   );
   if (!isCompiledQuery(prepared)) {
     return prepared;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -44,7 +44,6 @@ import { queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
 import {
   createResolveInfoThunk,
-  ResolveInfoEnricher,
   ResolveInfoEnricherInput
 } from "./resolve-info";
 import { compileVariableParsing } from "./variables";
@@ -64,7 +63,7 @@ export interface CompilerOptions {
   // the key should be the name passed to the Scalar or Enum type
   customSerializers: { [key: string]: (v: any) => any };
 
-  resolverInfoEnricher?: ResolveInfoEnricher<any>;
+  resolverInfoEnricher?: (inp: ResolveInfoEnricherInput) => object;
 }
 
 /**

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -42,7 +42,11 @@ import {
 import { GraphQLError as GraphqlJitError } from "./error";
 import { queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
-import { createResolveInfoThunk } from "./resolve-info";
+import {
+  createResolveInfoThunk,
+  ResolveInfoEnricher,
+  ResolveInfoEnricherInput
+} from "./resolve-info";
 import { compileVariableParsing } from "./variables";
 
 export interface CompilerOptions {
@@ -59,6 +63,8 @@ export interface CompilerOptions {
   // Map of serializers to override
   // the key should be the name passed to the Scalar or Enum type
   customSerializers: { [key: string]: (v: any) => any };
+
+  resolverInfoEnricher?: ResolveInfoEnricher<any>;
 }
 
 /**
@@ -132,6 +138,14 @@ export function compileQuery(
   }
   if (!document) {
     throw new Error("Must provide document");
+  }
+
+  if (
+    partialOptions &&
+    partialOptions.resolverInfoEnricher &&
+    typeof partialOptions.resolverInfoEnricher !== "function"
+  ) {
+    throw new Error("resolverInfoEnricher must be a function");
   }
   try {
     const options = {
@@ -948,15 +962,18 @@ function getExecutionInfo(
 
   context.dependencies.set(
     resolveInfoName,
-    createResolveInfoThunk({
-      schema,
-      fragments,
-      operation,
-      parentType,
-      fieldName,
-      fieldType,
-      fieldNodes
-    })
+    createResolveInfoThunk(
+      {
+        schema,
+        fragments,
+        operation,
+        parentType,
+        fieldName,
+        fieldType,
+        fieldNodes
+      },
+      context.options.resolverInfoEnricher
+    )
   );
   return `${resolveInfoName}(${GLOBAL_ROOT_NAME}, ${GLOBAL_VARIABLES_NAME}, ${serializeResponsePath(
     responsePath

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export {
   FieldExpansion,
   LeafField,
   TypeExpansion,
+  fieldExpansionEnricher,
   isLeafField
 } from "./resolve-info";


### PR DESCRIPTION
Not everyone will want to pay the extra cost for compiling the extensions to resolve info and this allows for consumers to extend their resolve info with other expensive tasks that can be moved to a compilation phase.