### PR TITLE
[RFC] compile createSourceEventStream

### DIFF
--- a/src/__benchmarks__/benchmarks.ts
+++ b/src/__benchmarks__/benchmarks.ts
@@ -1,5 +1,6 @@
 import Benchmark from "benchmark";
 import {
+  createSourceEventStream,
   DocumentNode,
   execute,
   getIntrospectionQuery,
@@ -7,6 +8,7 @@ import {
   parse
 } from "graphql";
 import { compileQuery, isCompiledQuery, isPromise } from "../execution";
+import { benchmarkCreateSourceEventStream } from "./createSourceEventStream";
 import {
   query as fewResolversQuery,
   schema as fewResolversSchema
@@ -51,8 +53,8 @@ const benchmarks: { [key: string]: BenchmarkMaterial } = {
 async function runBenchmarks() {
   const skipJS = process.argv[2] === "skip-js";
   const skipJSON = process.argv[2] === "skip-json";
-  const benchs = await Promise.all(
-    Object.entries(benchmarks).map(
+  const benchs = await Promise.all([
+    ...Object.entries(benchmarks).map(
       async ([bench, { query, schema, variables }]) => {
         const compiledQuery = compileQuery(schema, query, undefined, {
           debug: true
@@ -145,7 +147,9 @@ async function runBenchmarks() {
           });
         return suite;
       }
-    )
+    ),
+    benchmarkCreateSourceEventStream(),
+    ]
   );
 
   const benchsToRun = benchs.filter(isNotNull);

--- a/src/__benchmarks__/createSourceEventStream.ts
+++ b/src/__benchmarks__/createSourceEventStream.ts
@@ -1,0 +1,156 @@
+import Benchmark from "benchmark";
+import {
+  createSourceEventStream,
+  DocumentNode,
+  execute,
+  getIntrospectionQuery,
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  parse
+
+} from "graphql";
+import { compileQuery, isCompiledQuery, isPromise } from "../execution";
+import {
+} from "graphql";
+
+const schema = function schema() {
+  const BlogArticle: GraphQLObjectType = new GraphQLObjectType({
+    name: "Article",
+    fields: {
+      id: { type: new GraphQLNonNull(GraphQLID) },
+      isPublished: { type: GraphQLBoolean },
+      title: { type: GraphQLString },
+      body: { type: GraphQLString },
+      keywords: { type: new GraphQLList(GraphQLString) }
+    }
+  });
+
+  const BlogQuery = new GraphQLObjectType({
+    name: "Query",
+    fields: {
+      article: {
+        type: BlogArticle,
+        args: { id: { type: GraphQLID } },
+        resolve: (_, { id }) => article(id)
+      },
+    }
+  });
+  const BlogSubscription = new GraphQLObjectType({
+    name: "Subscription",
+    fields: {
+      news: {
+        type: BlogArticle,
+        args: {},
+        subscribe: async () => {
+          const it: AsyncIterable<any> = {
+            [Symbol.asyncIterator]() {
+              return {
+                next: async () => ({done: true, value: undefined})
+              }
+            },
+          }
+          return it;
+        }
+      },
+    }
+  });
+
+  function article(id: number): any {
+    return {
+      id,
+      isPublished: true,
+      title: "My Article " + id,
+      body: "This is a post",
+      hidden: "This data is not exposed in the schema",
+      keywords: ["foo", "bar", 1, true, null]
+    };
+  }
+
+  return new GraphQLSchema({
+    query: BlogQuery,
+    subscription: BlogSubscription
+  });
+}()
+
+const subscription = parse(`
+subscription {
+  news {
+    ...articleFields,
+  }
+}
+
+fragment articleFields on Article {
+  __typename
+  id,
+  isPublished,
+  title,
+  body,
+  hidden,
+  notdefined
+}
+`);
+
+const skipJS = false;
+
+export function benchmarkCreateSourceEventStream() {
+  const compiledQuery = compileQuery(schema, subscription, undefined, {
+    debug: true
+  } as any);
+  if (!isCompiledQuery(compiledQuery) || !compiledQuery.createSourceEventStream) {
+    // eslint-disable-next-line no-console
+    console.error(`failed to compile`);
+    return null;
+  }
+  const suite = new Benchmark.Suite('createSourceEventStream');
+  if (!skipJS) {
+    suite.add("graphql-js", {
+      minSamples: 150,
+      defer: true,
+      fn(deferred: any) {
+        const stream = createSourceEventStream(
+          schema,
+          subscription,
+          {},
+        );
+        if (isPromise(stream)) {
+          return stream.then((res) =>
+            deferred.resolve(res)
+          );
+        }
+        return deferred.resolve()
+      }
+    });
+  }
+  suite
+    .add("graphql-jit", {
+      minSamples: 150,
+      defer: true,
+      fn(deferred: any) {
+        const stream = compiledQuery.createSourceEventStream!(
+          {},
+          undefined
+        );
+        if (isPromise(stream)) {
+          return stream.then((res) =>
+            deferred.resolve(res)
+          );
+        }
+        return deferred.resolve()
+      }
+    })
+    // add listeners
+    .on("cycle", (event: any) => {
+      // eslint-disable-next-line no-console
+      console.log(String(event.target));
+    })
+    .on("start", () => {
+      // eslint-disable-next-line no-console
+      console.log("Starting createSourceEventStream");
+    });
+  return suite;
+}

--- a/src/__benchmarks__/createSourceEventStream.ts
+++ b/src/__benchmarks__/createSourceEventStream.ts
@@ -1,9 +1,6 @@
 import Benchmark from "benchmark";
 import {
   createSourceEventStream,
-  DocumentNode,
-  execute,
-  getIntrospectionQuery,
   GraphQLBoolean,
   GraphQLID,
   GraphQLList,
@@ -14,9 +11,8 @@ import {
   parse
 
 } from "graphql";
-import { compileQuery, isCompiledQuery, isPromise } from "../execution";
-import {
-} from "graphql";
+import { isPromise } from "../execution";
+import { compileSourceEventStream } from "..";
 
 const schema = function schema() {
   const BlogArticle: GraphQLObjectType = new GraphQLObjectType({
@@ -95,13 +91,14 @@ fragment articleFields on Article {
 }
 `);
 
+// TODO
 const skipJS = false;
 
 export function benchmarkCreateSourceEventStream() {
-  const compiledQuery = compileQuery(schema, subscription, undefined, {
+  const compiledQuery = compileSourceEventStream(schema, subscription, undefined, {
     debug: true
   } as any);
-  if (!isCompiledQuery(compiledQuery) || !compiledQuery.createSourceEventStream) {
+  if (!compiledQuery) {
     // eslint-disable-next-line no-console
     console.error(`failed to compile`);
     return null;
@@ -131,7 +128,7 @@ export function benchmarkCreateSourceEventStream() {
       minSamples: 150,
       defer: true,
       fn(deferred: any) {
-        const stream = compiledQuery.createSourceEventStream!(
+        const stream = compiledQuery(
           {},
           undefined
         );

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ export {
   compileQuery,
   isCompiledQuery,
   CompilerOptions,
-  CompiledQuery
+  CompiledQuery,
+  CreateSourceEventStream,
+  compileSourceEventStream
 } from "./execution";
 
 export {


### PR DESCRIPTION
Creating a source event stream from the compiled query is about 1.5 to 2 times faster. The use case for createSourceEventStream is running the event stream and resolvers in different processes. That means compiling the resolvers is not necessary and just costs performance, thus a separate function is exposed for just this use case.
It does not actually compile anything, but that's an implementation detail und thus `compileCreateSourceEventStream` name was chosen.

This needs some polishing and tests, but I would like to know if you're interested in this at all?

Relates-To: https://github.com/ParabolInc/parabol/issues/5468