### PR TITLE
fix: support latest version of graphql-17-alpha.9 release

### DIFF
--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -1,0 +1,33 @@
+name: "Setup Yarn"
+description: "Checkout, setup Node.js and cache Yarn packages"
+inputs:
+  node-version:
+    description: "The Node.js version to use"
+    required: true
+  cache-key-prefix:
+    description: "The prefix for the cache key"
+    required: false
+    default: "yarn"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      shell: bash
+      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+
+    - name: Cache yarn packages
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-${{ inputs.node-version }}-${{ inputs.cache-key-prefix }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.node-version }}-${{ inputs.cache-key-prefix }}-

--- a/.github/actions/setup-yarn/action.yml
+++ b/.github/actions/setup-yarn/action.yml
@@ -12,8 +12,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v4
-
     - name: Use Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,7 @@ jobs:
           cache-key-prefix: lint
 
       - name: Install dependencies
-        run: |
-          yarn config set enableImmutableInstalls false
-          yarn install
+        run: yarn install
 
       - name: Format and Lint check
         run: yarn check-tsc && yarn lint && yarn build && yarn check-exports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        graphql-version: [15, 16, 17.0.0-alpha.5]
+        graphql-version: [15, 16, 17.0.0-alpha.9]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,39 +7,15 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20, 22, 24]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        graphql-version: [15, 16, 17.0.0-alpha.9]
-
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Setup
+        uses: ./.github/actions/setup-yarn
         with:
-          node-version: ${{ matrix.node-version }}
-
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
-      - name: Cache yarn packages
-        uses: actions/cache@v4
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-${{matrix.node-version}}-${{matrix.graphql-version}}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{matrix.node-version}}-${{matrix.graphql-version}}-yarn-
-
-      - name: Use GraphQL v${{matrix.graphql-version}}
-        run: node ./scripts/match-graphql.js ${{matrix.graphql-version}}
+          node-version: 24
+          cache-key-prefix: lint
 
       - name: Install dependencies
         run: |
@@ -48,6 +24,30 @@ jobs:
 
       - name: Format and Lint check
         run: yarn check-tsc && yarn lint && yarn build && yarn check-exports
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint # Only run tests if linting passes
+
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+        graphql-version: [15, 16, 17.0.0-alpha.9]
+
+    steps:
+      - name: Setup
+        uses: ./.github/actions/setup-yarn
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache-key-prefix: test
+
+      - name: Use GraphQL v${{matrix.graphql-version}}
+        run: node ./scripts/match-graphql.js ${{matrix.graphql-version}}
+
+      - name: Install dependencies
+        run: |
+          yarn config set enableImmutableInstalls false
+          yarn install
 
       - name: Tests and Coverage
         run: yarn test --coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup
-        uses: ./.github/actions/setup-yarn
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-yarn
         with:
           node-version: 24
           cache-key-prefix: lint
@@ -35,8 +35,8 @@ jobs:
         graphql-version: [15, 16, 17.0.0-alpha.9]
 
     steps:
-      - name: Setup
-        uses: ./.github/actions/setup-yarn
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-yarn
         with:
           node-version: ${{ matrix.node-version }}
           cache-key-prefix: test

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -9,8 +9,7 @@ import {
   GraphQLSchema,
   GraphQLString,
   parse,
-  GraphQLInt,
-  versionInfo
+  GraphQLInt
 } from "graphql";
 import { compileQuery } from "../index";
 import { queryToJSONSchema } from "../json";

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -12,9 +12,9 @@ import {
   GraphQLInt,
   versionInfo
 } from "graphql";
-import { buildExecutionContext } from "graphql/execution/execute";
 import { compileQuery } from "../index";
 import { queryToJSONSchema } from "../json";
+import { buildCompilationContext } from "../execution";
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { formatError } from "../compat";
 
@@ -129,14 +129,13 @@ describe("json schema creator", () => {
     }
   `);
 
-  const context: any =
-    versionInfo.major > 15
-      ? (buildExecutionContext as any)({
-          schema: blogSchema,
-          document
-        })
-      : (buildExecutionContext as any)(blogSchema, document);
-  context.options = {};
+  const context = buildCompilationContext(blogSchema, document, {
+    customJSONSerializer: false,
+    disableLeafSerialization: false,
+    disablingCapturingStackErrors: false,
+    customSerializers: {},
+    useExperimentalPathBasedSkipInclude: false
+  });
   const jsonSchema = queryToJSONSchema(context);
   test("json schema creation", () => {
     expect(jsonSchema).toMatchSnapshot();
@@ -207,14 +206,13 @@ describe("JSON schema creation with abstract types", () => {
       u
     }
   `);
-  const context: any =
-    versionInfo.major > 15
-      ? (buildExecutionContext as any)({
-          schema,
-          document
-        })
-      : (buildExecutionContext as any)(schema, document);
-  context.options = {};
+  const context = buildCompilationContext(schema, document, {
+    customJSONSerializer: false,
+    disableLeafSerialization: false,
+    disablingCapturingStackErrors: false,
+    customSerializers: {},
+    useExperimentalPathBasedSkipInclude: false
+  });
 
   const jsonSchema = queryToJSONSchema(context);
   test("json schema creation", () => {

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -400,7 +400,9 @@ describe("Execute: Handles execution with a complex schema", () => {
   });
 
   test("executes IntrospectionQuery", () => {
-    const queryAST = parse(getIntrospectionQuery({ descriptions: true }));
+    const queryAST = parse(
+      getIntrospectionQuery({ descriptions: true, inputValueDeprecation: true })
+    );
     const result = executeQuery(
       BlogSchema,
       queryAST

--- a/src/__tests__/union-interface.test.ts
+++ b/src/__tests__/union-interface.test.ts
@@ -116,20 +116,20 @@ describe("Execute: Union and intersection types", () => {
         Named: __type(name: "Named") {
           kind
           name
-          fields { name }
+          fields(includeDeprecated: true) { name }
           interfaces { name }
           possibleTypes { name }
-          enumValues { name }
-          inputFields { name }
+          enumValues(includeDeprecated: true) { name }
+          inputFields(includeDeprecated: true) { name }
         }
         Pet: __type(name: "Pet") {
           kind
           name
-          fields { name }
+          fields(includeDeprecated: true) { name }
           interfaces { name }
           possibleTypes { name }
-          enumValues { name }
-          inputFields { name }
+          enumValues(includeDeprecated: true) { name }
+          inputFields(includeDeprecated: true) { name }
         }
       }
     `);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,6 +1,7 @@
 import {
   type ArgumentNode,
   type ASTNode,
+  type ConstValueNode,
   type DirectiveNode,
   type FieldNode,
   type FragmentDefinitionNode,
@@ -34,7 +35,11 @@ import {
 } from "graphql";
 import { type CompilationContext, GLOBAL_VARIABLES_NAME } from "./execution.js";
 import createInspect from "./inspect.js";
-import { getGraphQLErrorOptions, resolveFieldDef } from "./compat.js";
+import {
+  coerceInputLiteral,
+  getGraphQLErrorOptions,
+  resolveFieldDef
+} from "./compat.js";
 
 export interface JitFieldNode extends FieldNode {
   /**
@@ -945,18 +950,14 @@ export function valueFromAST(
   }
 
   if (isScalarType(type)) {
-    // Scalars fulfill parsing a literal value via parseLiteral().
+    // Scalars fulfill parsing a literal value via coerceInputLiteral().
     // Invalid values represent a failure to parse correctly, in which case
     // no value is returned.
     let result: any;
     try {
-      if (type.parseLiteral.length > 1) {
-        // eslint-disable-next-line
-        console.error(
-          "Scalar with variable inputs detected for parsing AST literals. This is not supported."
-        );
-      }
-      result = type.parseLiteral(valueNode, {});
+      // Use coerceInputLiteral if available (v17+), otherwise fall back to parseLiteral
+      // By this point, we've filtered out VARIABLE nodes, so valueNode is a ConstValueNode
+      result = coerceInputLiteral(type, valueNode as ConstValueNode);
     } catch (error) {
       return; // Invalid: intentionally return no value.
     }

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -954,7 +954,6 @@ export function valueFromAST(
     // no value is returned.
     let result: any;
     try {
-      // Use coerceInputLiteral if available (v17+), otherwise fall back to parseLiteral
       // By this point, we've filtered out VARIABLE nodes, so valueNode is a ConstValueNode
       result = coerceInputLiteral(type, valueNode as ConstValueNode);
     } catch (error) {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -30,7 +30,6 @@ import {
   type SelectionNode,
   type TypeNode,
   isAbstractType,
-  Source,
   Location
 } from "graphql";
 import { type CompilationContext, GLOBAL_VARIABLES_NAME } from "./execution.js";

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,7 +1,6 @@
 import {
   type ArgumentNode,
   type ASTNode,
-  type ConstValueNode,
   type DirectiveNode,
   type FieldNode,
   type FragmentDefinitionNode,
@@ -32,6 +31,7 @@ import {
   isAbstractType,
   Location
 } from "graphql";
+import { type ConstValueNode } from "./compat.js";
 import { type CompilationContext, GLOBAL_VARIABLES_NAME } from "./execution.js";
 import createInspect from "./inspect.js";
 import {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -29,9 +29,9 @@ import {
   type SelectionNode,
   type TypeNode,
   isAbstractType,
-  Location
+  Location,
+  type ConstValueNode
 } from "graphql";
-import { type ConstValueNode } from "./compat.js";
 import { type CompilationContext, GLOBAL_VARIABLES_NAME } from "./execution.js";
 import createInspect from "./inspect.js";
 import {

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -8,14 +8,28 @@ import {
   type OperationDefinitionNode,
   type GraphQLObjectType,
   type GraphQLFormattedError,
-  GraphQLScalarType,
-  ConstValueNode
+  GraphQLScalarType
 } from "graphql";
 import { type Maybe } from "./types.js";
 import * as errorUtilities from "graphql/error/index.js";
 import * as utilities from "graphql/utilities/index.js";
 import { type CompilationContext } from "./execution.js";
 import * as execute from "graphql/execution/execute.js";
+
+import type * as GraphQL from "graphql";
+
+// GraphQL v15 does not have ConstValueNode type
+export type ConstValueNode = "ConstValueNode" extends keyof typeof GraphQL
+  ? GraphQL.ConstValueNode
+  :
+      | GraphQL.IntValueNode
+      | GraphQL.FloatValueNode
+      | GraphQL.StringValueNode
+      | GraphQL.BooleanValueNode
+      | GraphQL.NullValueNode
+      | GraphQL.EnumValueNode
+      | GraphQL.ListValueNode
+      | GraphQL.ObjectValueNode;
 
 /**
  * A helper file to support backward compatibility for different versions of graphql-js.

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -118,14 +118,18 @@ export function resolveFieldDef(
 
 /**
  * v17 deprecates parseLiteral in favor of coerceInputLiteral for custom scalars
+ * However, custom scalars may still only define parseLiteral, so we check
+ * for the method's existence rather than just the version.
  */
 export function coerceInputLiteral(
   type: GraphQLScalarType<unknown, unknown>,
   valueNode: ConstValueNode
 ): any {
-  if (versionInfo.major < 17) {
-    return (type as any).parseLiteral(valueNode, {});
+  // Use coerceInputLiteral if available (built-in scalars in v17+)
+  // Otherwise fall back to parseLiteral (custom scalars, or v16)
+  if ((type as any).coerceInputLiteral) {
+    return (type as any).coerceInputLiteral(valueNode);
   }
 
-  return (type as any).coerceInputLiteral(valueNode);
+  return (type as any).parseLiteral(valueNode, {});
 }

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -8,6 +8,7 @@ import {
   type OperationDefinitionNode,
   type GraphQLObjectType,
   type GraphQLFormattedError,
+  type ConstValueNode,
   GraphQLScalarType
 } from "graphql";
 import { type Maybe } from "./types.js";
@@ -15,21 +16,6 @@ import * as errorUtilities from "graphql/error/index.js";
 import * as utilities from "graphql/utilities/index.js";
 import { type CompilationContext } from "./execution.js";
 import * as execute from "graphql/execution/execute.js";
-
-import type * as GraphQL from "graphql";
-
-// GraphQL v15 does not have ConstValueNode type
-export type ConstValueNode = "ConstValueNode" extends keyof typeof GraphQL
-  ? GraphQL.ConstValueNode
-  :
-      | GraphQL.IntValueNode
-      | GraphQL.FloatValueNode
-      | GraphQL.StringValueNode
-      | GraphQL.BooleanValueNode
-      | GraphQL.NullValueNode
-      | GraphQL.EnumValueNode
-      | GraphQL.ListValueNode
-      | GraphQL.ObjectValueNode;
 
 /**
  * A helper file to support backward compatibility for different versions of graphql-js.

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -7,7 +7,9 @@ import {
   type ASTNode,
   type OperationDefinitionNode,
   type GraphQLObjectType,
-  type GraphQLFormattedError
+  type GraphQLFormattedError,
+  GraphQLScalarType,
+  ConstValueNode
 } from "graphql";
 import { type Maybe } from "./types.js";
 import * as errorUtilities from "graphql/error/index.js";
@@ -112,4 +114,18 @@ export function resolveFieldDef(
     parentType,
     fieldNode.name.value
   );
+}
+
+/**
+ * v17 deprecates parseLiteral in favor of coerceInputLiteral for custom scalars
+ */
+export function coerceInputLiteral(
+  type: GraphQLScalarType<unknown, unknown>,
+  valueNode: ConstValueNode
+): any {
+  if (versionInfo.major < 17) {
+    return (type as any).parseLiteral(valueNode, {});
+  }
+
+  return (type as any).coerceInputLiteral(valueNode);
 }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -101,7 +101,8 @@ export interface CompilerOptions {
   useExperimentalPathBasedSkipInclude: boolean;
 }
 
-interface ExecutionContext {
+// @internal
+export interface ExecutionContext {
   promiseCounter: number;
   data: any;
   errors: GraphQLError[];
@@ -163,6 +164,11 @@ export interface CompilationContext extends GraphQLContext {
   deferred: DeferredField[];
   options: CompilerOptions;
   depth: number;
+
+  // GraphQL-JS v17 compatibility
+  schema: GraphQLSchema;
+  operation: OperationDefinitionNode;
+  fragments: { [key: string]: FragmentDefinitionNode };
 }
 
 // prefix for the variable used ot cache validation results
@@ -1572,7 +1578,7 @@ function defaultResolveTypeFn(
  *
  * Throws a GraphQLError if a valid execution context cannot be created.
  */
-function buildCompilationContext(
+export function buildCompilationContext(
   schema: GraphQLSchema,
   document: DocumentNode,
   options: CompilerOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4667,9 +4667,9 @@ __metadata:
   linkType: soft
 
 "graphql@npm:^16.8.0":
-  version: 16.8.1
-  resolution: "graphql@npm:16.8.1"
-  checksum: 10c0/129c318156b466f440914de80dbf7bc67d17f776f2a088a40cb0da611d19a97c224b1c6d2b13cbcbc6e5776e45ed7468b8432f9c3536724e079b44f1a3d57a8a
+  version: 16.12.0
+  resolution: "graphql@npm:16.12.0"
+  checksum: 10c0/b6fffa4e8a4e4a9933ebe85e7470b346dbf49050c1a482fac5e03e4a1a7bed2ecd3a4c97e29f04457af929464bc5e4f2aac991090c2f320111eef26e902a5c75
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Deprecate Node18, add Node24.

Handle breaking changes in graphql 17-alpha.9 release - 

1. `parseLiteral` → `coerceInputLiteral` - detect version and use the right function
2. `buildExecutionContext` removed. Replace it with `buildCompilationContext` in tests
3. Introspection Schema: `includeDeprecated` Now Required. Add it in the introspection query tests and in `getIntrospectionQuery({inputValueDeprecation: true})`

The build pipeline is split into two separate pipelines - 

1. `lint` - tsc, build, linter (matrix: none)
2. `test` - run tests (matrix: node 20,22,24; graphql 15,16,17-alpha)

This is because it is harder to achieve compatibility in the breaking type changes like GraphQLScalarType (generic vs no generic in older versions), ConstValueNode not available in older versions, etc. So we run build, and TSC only on current dev version in the repo (v16). But we run tests against all supported versions of graphql-js. 
