### PR TITLE
fix(error): make GraphQLError.extensions mandatory

### DIFF
--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -75,4 +75,50 @@ describe("error generation", () => {
       Error.captureStackTrace = captureStackTrace;
     });
   });
+  describe("extensions", () => {
+    test("extensions is always an empty object even without originalError extensions", () => {
+      const resp = executeTestQuery("{ a }", false);
+      // Schema field 'a' returns normally, but we can test with a thrown error without extensions
+      const error = new GraphQLError("test error");
+      expect(error.extensions).toEqual({});
+    });
+    test("extensions is enumerable (appears in JSON.stringify)", () => {
+      const error = new GraphQLError("test error");
+      const json = JSON.stringify(error);
+      expect(json).toContain('"extensions":{}');
+    });
+    test("extensions with custom data from originalError is preserved", () => {
+      const originalError = new Error("original");
+      (originalError as any).extensions = { custom: "data" };
+      const error = new (GraphQLError as any)(
+        "test",
+        undefined,
+        undefined,
+        originalError
+      );
+      expect(error.extensions).toEqual({ custom: "data" });
+    });
+    test("null extensions coerces to empty object", () => {
+      const originalError = new Error("original");
+      (originalError as any).extensions = null;
+      const error = new (GraphQLError as any)(
+        "test",
+        undefined,
+        undefined,
+        originalError
+      );
+      expect(error.extensions).toEqual({});
+    });
+    test("false extensions coerces to empty object", () => {
+      const originalError = new Error("original");
+      (originalError as any).extensions = false;
+      const error = new (GraphQLError as any)(
+        "test",
+        undefined,
+        undefined,
+        originalError
+      );
+      expect(error.extensions).toEqual({});
+    });
+  });
 });

--- a/src/__tests__/execution.test.ts
+++ b/src/__tests__/execution.test.ts
@@ -641,6 +641,38 @@ describe("Execute: Handles basic execution tasks", () => {
     });
   });
 
+  test("errors include extensions field even without custom extensions", async () => {
+    const query = `
+      query {
+        asyncError
+      }
+    `;
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: "Query",
+        fields: {
+          asyncError: {
+            type: GraphQLString,
+            resolve() {
+              throw new Error("Test error without extensions");
+            }
+          }
+        }
+      })
+    });
+
+    const ast = parse(query);
+    const result = await executeQuery(schema, ast);
+
+    expect(result.errors).toBeDefined();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      message: "Test error without extensions",
+      extensions: {}
+    });
+  });
+
   test("Full response path is included for non-nullable fields", async () => {
     const A: GraphQLObjectType = new GraphQLObjectType({
       name: "A",

--- a/src/error.ts
+++ b/src/error.ts
@@ -32,10 +32,10 @@ export function GraphQLError(
       value: originalError
     },
     extensions: {
-      // Coercing falsey values to undefined ensures they will not be included
-      // in JSON.stringify() when not provided.
-      value: extensions || undefined,
-      enumerable: Boolean(extensions)
+      // Always initialize extensions as an empty object to match graphql-js v17+
+      // This ensures extensions is always present and enumerable for JSON serialization.
+      value: extensions || {},
+      enumerable: true
     }
   });
 


### PR DESCRIPTION
BREAKING CHANGE: GraphQLError.extensions is now always initialized as an empty object {} instead of being undefined for errors without custom extensions. This aligns graphql-jit with graphql-js v17+ specification and fixes compatibility with Apollo Server v4.

Changes:
- extensions property is now always present on GraphQLError instances
- extensions property is now always enumerable (included in JSON serialization)
- falsey values (null, false, etc.) coerce to empty object {}
- existing code using optional chaining (error.extensions?.custom) is unaffected

Impact:
- Only affects code that explicitly checks if (error.extensions) to detect
  custom extensions. Migration: use if (Object.keys(error.extensions).length > 0)
- JSON error responses now include "extensions": {} even without custom extensions