### PR TITLE
fix: publish config for OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,13 @@ on:
 jobs:
   publish:
     # prevents this action from running on forks
-    if: github.repository == 'zalando-incubator/graphql-jit'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     steps:
+      - name: Debug
+        run: echo "repo=${{ github.repository }}"
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,19 +6,25 @@ on:
   release:
     types:
       - created
-
-permissions:
-  id-token: write
-  contents: read
+    # temp
+    pull_request:
+      branches:
+        - main
 
 jobs:
-  build:
+  publish:
+    # prevents this action from running on forks
+    if: github.repository == 'zalando-incubator/graphql-jit'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 20
+          package-manager-cache: false
       - run: yarn install --immutable
 
       - name: Publish Canary
@@ -37,3 +43,14 @@ jobs:
           RELEASE_VERSION="${RELEASE_VERSION#v}"
           npm pkg set version="$RELEASE_VERSION"
           npm publish --tag latest
+
+      # temp
+      - name: Publish PR Canary
+        if: github.event_name == 'pull_request'
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          CANARY_VERSION="${BASE_VERSION}-canary.pr${PR_NUMBER}.${SHORT_SHA}"
+          npm pkg set version="$CANARY_VERSION"
+          npm publish --tag "pr-${PR_NUMBER}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,9 @@ on:
     types:
       - created
     # temp
-    pull_request:
-      branches:
-        - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,21 +6,21 @@ on:
   release:
     types:
       - created
-    # temp
-  pull_request:
-    branches:
-      - main
+  # To enable PR publishes
+  # Uncomment the following lines and also the lines in the publish job below
+  # pull_request:
+  #   branches:
+  #     - main
 
 jobs:
   publish:
     # prevents this action from running on forks
+    if: github.repository == 'zalando-incubator/graphql-jit'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
     steps:
-      - name: Debug
-        run: echo "repo=${{ github.repository }}"
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
@@ -45,13 +45,13 @@ jobs:
           npm pkg set version="$RELEASE_VERSION"
           npm publish --tag latest
 
-      # temp
-      - name: Publish PR Canary
-        if: github.event_name == 'pull_request'
-        run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          BASE_VERSION=$(node -p "require('./package.json').version")
-          CANARY_VERSION="${BASE_VERSION}-canary.pr${PR_NUMBER}.${SHORT_SHA}"
-          npm pkg set version="$CANARY_VERSION"
-          npm publish --tag "pr-${PR_NUMBER}"
+      # To enable PR publishes, uncomment the following lines and also the lines in the on: section above
+      # - name: Publish PR Canary
+      #   if: github.event_name == 'pull_request'
+      #   run: |
+      #     SHORT_SHA=$(git rev-parse --short HEAD)
+      #     PR_NUMBER="${{ github.event.pull_request.number }}"
+      #     BASE_VERSION=$(node -p "require('./package.json').version")
+      #     CANARY_VERSION="${BASE_VERSION}-canary.pr${PR_NUMBER}.${SHORT_SHA}"
+      #     npm pkg set version="$CANARY_VERSION"
+      #     npm publish --tag "pr-${PR_NUMBER}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           package-manager-cache: false
       - run: yarn install --immutable
 


### PR DESCRIPTION
- permissions inside the job
- set node version to 24 as npm min version to support OIDC is 11.5 and at least node 22 is required.
- condition that forks do not run publish
- Pr publish optional
