### PR TITLE
Memory optimizations of compiled code

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     }
   },
   "scripts": {
-    "benchmark": "NODE_ENV=production ./src/__benchmarks__/benchmarks.ts",
+    "benchmark": "NODE_ENV=production node --loader @swc-node/register/esm src/__benchmarks__/benchmarks.ts",
     "build": "yarn tsup-node",
     "check-exports": "attw --pack .",
     "check-tsc": "tsc --noEmit",

--- a/src/__tests__/abstract.test.ts
+++ b/src/__tests__/abstract.test.ts
@@ -4,8 +4,10 @@
 
 import {
   GraphQLBoolean,
+  GraphQLID,
   GraphQLInterfaceType,
   GraphQLList,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLResolveInfo,
   GraphQLSchema,
@@ -682,5 +684,114 @@ describe("Execute: Handles execution of abstract types", () => {
         }
       });
     }
+  });
+});
+
+describe("Abstract type trivial case deduplication", () => {
+  // Builds a union of N types each only exposing __typename (no resolvers).
+  // The compiler groups all trivial cases into a shared block using finalType.
+  // Every member must still return its own correct __typename, not a shared
+  // constant from the first compiled case.
+  test("each trivial union member returns its own __typename", async () => {
+    const typeNames = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"];
+    const memberTypes = typeNames.map(
+      (name) =>
+        new GraphQLObjectType({
+          name,
+          fields: { id: { type: GraphQLID } }
+        })
+    );
+
+    const SearchResult = new GraphQLUnionType({
+      name: "SearchResult",
+      types: memberTypes,
+      resolveType: (obj) => obj.__type
+    });
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: "Query",
+        fields: {
+          search: {
+            type: new GraphQLList(SearchResult),
+            resolve: () =>
+              typeNames.map((name) => ({ __type: name, id: `id-${name}` }))
+          }
+        }
+      })
+    });
+
+    const document = parse(`{ search { __typename } }`);
+    const compiled = compileQuery(schema, document, "");
+    if (!isCompiledQuery(compiled)) throw new Error("compile failed");
+
+    const result = await compiled.query(undefined, undefined, undefined);
+    expect(result.errors).toBeUndefined();
+    expect(result.data!.search).toEqual(
+      typeNames.map((name) => ({ __typename: name }))
+    );
+  });
+
+  // A union where some members are trivial (__typename only, grouped into a
+  // shared case) and some are non-trivial (have resolver-backed fields, get
+  // individual cases). Both paths must execute correctly in the same query.
+  test("mixed trivial and non-trivial union members both work correctly", async () => {
+    const TrivialA = new GraphQLObjectType({
+      name: "TrivialA",
+      fields: { id: { type: GraphQLID } }
+    });
+    const TrivialB = new GraphQLObjectType({
+      name: "TrivialB",
+      fields: { id: { type: GraphQLID } }
+    });
+    const Rich = new GraphQLObjectType({
+      name: "Rich",
+      fields: {
+        id: { type: GraphQLID },
+        label: {
+          type: new GraphQLNonNull(GraphQLString),
+          resolve: (obj) => obj.label
+        }
+      }
+    });
+
+    const Item = new GraphQLUnionType({
+      name: "Item",
+      types: [TrivialA, TrivialB, Rich],
+      resolveType: (obj) => obj.__type
+    });
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: "Query",
+        fields: {
+          items: {
+            type: new GraphQLList(Item),
+            resolve: () => [
+              { __type: "TrivialA", id: "1" },
+              { __type: "Rich", id: "2", label: "hello" },
+              { __type: "TrivialB", id: "3" }
+            ]
+          }
+        }
+      })
+    });
+
+    const document = parse(`{
+      items {
+        __typename
+        ... on Rich { label }
+      }
+    }`);
+    const compiled = compileQuery(schema, document, "");
+    if (!isCompiledQuery(compiled)) throw new Error("compile failed");
+
+    const result = await compiled.query(undefined, undefined, undefined);
+    expect(result.errors).toBeUndefined();
+    expect(result.data!.items).toEqual([
+      { __typename: "TrivialA" },
+      { __typename: "Rich", label: "hello" },
+      { __typename: "TrivialB" }
+    ]);
   });
 });

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -659,10 +659,60 @@ function compileType(
   previousPath: ObjectPath
 ): string {
   const sourcePath = joinOriginPaths(originPaths);
+  const isNonNull = isNonNullType(type);
+  const innerType = isNonNull ? (type as any).ofType : type;
+
+  // Optimization: replace the null→instanceof cascade with a single monomorphic
+  // runtime call for leaf types. Avoids N separate GraphQLError call sites per
+  // query and lets V8 optimize a single IC instead of one per field.
+  if (
+    isLeafType(innerType) &&
+    !(
+      context.options.disableLeafSerialization &&
+      (innerType instanceof GraphQLEnumType || isSpecifiedScalarType(innerType))
+    )
+  ) {
+    const dest = isNonNull ? GLOBAL_NULL_ERRORS_NAME : GLOBAL_ERRORS_NAME;
+    const serializerName = getSerializerName(innerType.name);
+    context.serializers[serializerName] = getSerializer(
+      innerType,
+      context.options.customSerializers[innerType.name]
+    );
+    const parentIndexes = getParentArgIndexes(context);
+    const errHandler = getHoistedFunctionName(
+      context,
+      `${innerType.name}${originPaths.join("")}SerializerErrorHandler`
+    );
+    context.hoistedFunctions.push(`
+    function ${errHandler}(${GLOBAL_EXECUTION_CONTEXT}, message, ${parentIndexes}) {
+    ${dest}.push(${createErrorObject(
+      context,
+      fieldNodes,
+      previousPath,
+      "message"
+    )});}
+    `);
+    const locs = JSON.stringify(computeLocations(fieldNodes));
+    const path = serializeResponsePathAsArray(previousPath);
+    const capStack = context.options.disablingCapturingStackErrors
+      ? "true"
+      : "false";
+    const serializerRef = `${GLOBAL_EXECUTION_CONTEXT}.serializers.${serializerName}`;
+    const extraIndexes = parentIndexes ? `, ${parentIndexes}` : "";
+    if (isNonNull) {
+      const nullMsg = `"Cannot return null for non-nullable field ${
+        parentType.name
+      }.${getFieldNodesName(fieldNodes)}."`;
+      return `${GLOBAL_RUNTIME_NAME}.checkNonNullLeaf(${GLOBAL_EXECUTION_CONTEXT}, ${sourcePath}, ${dest}, ${nullMsg}, ${locs}, ${path}, ${capStack}, ${serializerRef}, ${errHandler}${extraIndexes})`;
+    } else {
+      return `${GLOBAL_RUNTIME_NAME}.checkNullableLeaf(${GLOBAL_EXECUTION_CONTEXT}, ${sourcePath}, ${dest}, ${locs}, ${path}, ${capStack}, ${serializerRef}, ${errHandler}${extraIndexes})`;
+    }
+  }
+
   let body = `${sourcePath} == null ? `;
   let errorDestination;
   if (isNonNullType(type)) {
-    type = type.ofType;
+    type = (type as any).ofType;
     const nullErrorStr = `"Cannot return null for non-nullable field ${
       parentType.name
     }.${getFieldNodesName(fieldNodes)}."`;

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -161,6 +161,7 @@ export interface CompilationContext extends GraphQLContext {
   };
   hoistedFunctions: string[];
   hoistedFunctionNames: Map<string, number>;
+  leafErrHandlerCache: Map<string, string>;
   typeResolvers: { [key: string]: GraphQLTypeResolver<any, any> };
   isTypeOfs: { [key: string]: GraphQLIsTypeOfFn<any, any> };
   resolveInfos: { [key: string]: any };
@@ -679,19 +680,27 @@ function compileType(
       context.options.customSerializers[innerType.name]
     );
     const parentIndexes = getParentArgIndexes(context);
-    const errHandler = getHoistedFunctionName(
-      context,
-      `${innerType.name}${originPaths.join("")}SerializerErrorHandler`
-    );
-    context.hoistedFunctions.push(`
-    function ${errHandler}(${GLOBAL_EXECUTION_CONTEXT}, message, ${parentIndexes}) {
-    ${dest}.push(${createErrorObject(
+    const handlerBody = `${dest}.push(${createErrorObject(
       context,
       fieldNodes,
       previousPath,
       "message"
-    )});}
-    `);
+    )});`;
+    const cachedHandler = context.leafErrHandlerCache.get(handlerBody);
+    let errHandler: string;
+    if (cachedHandler) {
+      errHandler = cachedHandler;
+    } else {
+      errHandler = getHoistedFunctionName(
+        context,
+        `${innerType.name}${originPaths.join("")}SerializerErrorHandler`
+      );
+      context.hoistedFunctions.push(`
+        function ${errHandler}(${GLOBAL_EXECUTION_CONTEXT}, message, ${parentIndexes}) {
+        ${handlerBody}}
+      `);
+      context.leafErrHandlerCache.set(handlerBody, errHandler);
+    }
     const locs = JSON.stringify(computeLocations(fieldNodes));
     const path = serializeResponsePathAsArray(previousPath);
     const capStack = context.options.disablingCapturingStackErrors
@@ -1636,6 +1645,7 @@ export function buildCompilationContext(
     resolveInfos: {},
     hoistedFunctions: [],
     hoistedFunctionNames: new Map(),
+    leafErrHandlerCache: new Map(),
     deferred: [],
     depth: -1,
     variableValues: {},

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -480,8 +480,6 @@ function compileOperation(
       ${GLOBAL_EXECUTION_CONTEXT}.jobCounter = 1; // since the first one will be run manually
       ${GLOBAL_EXECUTION_CONTEXT}.queue[0](${GLOBAL_EXECUTION_CONTEXT});
     }
-    // Promises have been scheduled so a new promise is returned
-    // that will be resolved once every promise is done
     if (${GLOBAL_PROMISE_COUNTER} > 0) {
       return new Promise(resolve => ${GLOBAL_EXECUTION_CONTEXT}.finalResolve = resolve);
     }
@@ -489,11 +487,7 @@ function compileOperation(
   } else {
     body += compileDeferredFields(context);
     body += `
-    // Promises have been scheduled so a new promise is returned
-    // that will be resolved once every promise is done
-    if (${GLOBAL_PROMISE_COUNTER} > 0) {
-      return new Promise(resolve => ${GLOBAL_RESOLVE} = resolve);
-    }`;
+    return ${GLOBAL_RUNTIME_NAME}.finalizeResult(${GLOBAL_EXECUTION_CONTEXT});`;
   }
   body += `
   // sync execution, the results are ready
@@ -589,13 +583,8 @@ function compileDeferredField(
   const body = `
     ${compiledArgs}
     if (${validArgs} === true) {
-      var __value = null;
-      try {
-        __value = ${resolverCall};
-      } catch (err) {
-        ${getErrorDestination(fieldType)}.push(${executionError});
-      }
-      ${GLOBAL_RUNTIME_NAME}.handleResolverResult(${GLOBAL_EXECUTION_CONTEXT}, __value,
+      ${GLOBAL_RUNTIME_NAME}.callResolver(${GLOBAL_EXECUTION_CONTEXT},
+        () => ${resolverCall},
         result => {
           ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${resultParentPath}, result, ${parentIndexes});
         },

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -162,6 +162,9 @@ export interface CompilationContext extends GraphQLContext {
   hoistedFunctions: string[];
   hoistedFunctionNames: Map<string, number>;
   leafErrHandlerCache: Map<string, string>;
+  // When set, emits this variable name instead of the hardcoded type name for __typename.
+  // Used by compileAbstractType to share trivial case bodies via the finalType variable.
+  trivialTypeNameVar?: string;
   typeResolvers: { [key: string]: GraphQLTypeResolver<any, any> };
   isTypeOfs: { [key: string]: GraphQLIsTypeOfFn<any, any> };
   resolveInfos: { [key: string]: any };
@@ -957,7 +960,9 @@ function compileObjectType(
       fieldCondition = "true";
     }
 
-    const alwaysIncluded = fieldCondition === "true";
+    const alwaysIncluded = fieldCondition
+      .split(" || ")
+      .every((p) => p === "true");
 
     if (!alwaysIncluded) {
       body(`(${fieldCondition})`);
@@ -966,8 +971,9 @@ function compileObjectType(
     // Inline __typename
     // No need to call a resolver for typename
     if (field === TypeNameMetaFieldDef) {
+      const typenameValue = context.trivialTypeNameVar ?? `"${type.name}"`;
       body(
-        alwaysIncluded ? `"${type.name}",` : `? "${type.name}" : undefined,`
+        alwaysIncluded ? `${typenameValue},` : `? ${typenameValue} : undefined,`
       );
       continue;
     }
@@ -1046,28 +1052,54 @@ function compileAbstractType(
   }
   const typeResolverName = getTypeResolverName(type.name);
   context.typeResolvers[typeResolverName] = resolveType;
-  const collectedTypes = context.schema
-    .getPossibleTypes(type)
-    .map((objectType) => {
-      const subContext = createSubCompilationContext(context);
-      const object = compileType(
-        subContext,
-        parentType,
-        objectType,
-        fieldNodes,
-        originPaths,
-        ["__concrete"],
-        addPath(previousPath, objectType.name, "meta")
-      );
-      return `case "${objectType.name}": {
-                  ${generateUniqueDeclarations(subContext)}
-                  const __concrete = ${object};
-                  ${compileDeferredFields(subContext)}
-                  return __concrete;
-              }`;
-    })
-    .join("\n");
+
   const finalTypeName = "finalType";
+
+  // Trivial types (no deferred resolvers) whose case bodies differ only in
+  // the __typename literal are grouped into a single shared case that uses
+  // the already computed finalType variable instead of a hardcoded string.
+  const trivialGroups = new Map<string, string[]>();
+  const nonTrivialCases: string[] = [];
+
+  for (const objectType of context.schema.getPossibleTypes(type)) {
+    const subContext = createSubCompilationContext(context);
+    subContext.trivialTypeNameVar = finalTypeName;
+    const object = compileType(
+      subContext,
+      parentType,
+      objectType,
+      fieldNodes,
+      originPaths,
+      ["__concrete"],
+      addPath(previousPath, objectType.name, "meta")
+    );
+    if (subContext.deferred.length === 0) {
+      // object was compiled with trivialTypeNameVar
+      // group identical bodies to share a single case
+      const group = trivialGroups.get(object) ?? [];
+      group.push(objectType.name);
+      trivialGroups.set(object, group);
+    } else {
+      nonTrivialCases.push(`case "${objectType.name}": {
+          ${generateUniqueDeclarations(subContext)}
+          const __concrete = ${object};
+          ${compileDeferredFields(subContext)}
+          return __concrete;
+      }`);
+    }
+  }
+
+  const trivialCases = Array.from(trivialGroups.entries()).map(
+    ([sharedObj, typeNames]) => {
+      const caseLabels = typeNames.map((n) => `case "${n}"`).join(": ");
+      return `${caseLabels}: {
+          const __concrete = ${sharedObj};
+          return __concrete;
+      }`;
+    }
+  );
+
+  const collectedTypes = [...nonTrivialCases, ...trivialCases].join("\n");
   const nullTypeError = `"Runtime Object type is not a possible type for \\"${type.name}\\"."`;
 
   const notPossibleTypeError =

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1,6 +1,9 @@
 import { type TypedDocumentNode } from "@graphql-typed-document-node/core";
 import fastJson from "fast-json-stringify";
 import { genFn } from "./generate";
+import { jitRuntime, type JitRuntime } from "./runtime";
+
+const GLOBAL_RUNTIME_NAME = "__context.rt";
 import {
   type ASTNode,
   type DocumentNode,
@@ -107,12 +110,12 @@ export interface ExecutionContext {
   data: any;
   errors: GraphQLError[];
   nullErrors: GraphQLError[];
-  resolve?: () => void;
+  resolve?: (ctx: ExecutionContext) => void;
+  rt: JitRuntime;
   inspect: typeof inspect;
   variables: { [key: string]: any };
   context: any;
   rootValue: any;
-  safeMap: typeof safeMap;
   GraphQLError: typeof GraphqlJitError;
   resolvers: { [key: string]: GraphQLFieldResolver<any, any, any> };
   trimmer: NullTrimmer;
@@ -182,7 +185,7 @@ const GLOBAL_CONTEXT_NAME = "__context.context";
 const GLOBAL_EXECUTION_CONTEXT = "__context";
 const GLOBAL_PROMISE_COUNTER = "__context.promiseCounter";
 const GLOBAL_INSPECT_NAME = "__context.inspect";
-const GLOBAL_SAFE_MAP_NAME = "__context.safeMap";
+const GLOBAL_SAFE_MAP_NAME = `${GLOBAL_RUNTIME_NAME}.safeMap`;
 const GRAPHQL_ERROR = "__context.GraphQLError";
 const GLOBAL_RESOLVE = "__context.resolve";
 const GLOBAL_PARENT_NAME = "__parent";
@@ -377,7 +380,6 @@ export function createBoundQuery(
         rootValue,
         context,
         variables: parsedVariables.coerced,
-        safeMap,
         inspect,
         GraphQLError: GraphqlJitError,
         resolvers,
@@ -386,6 +388,7 @@ export function createBoundQuery(
         serializers,
         resolveInfos,
         trimmer,
+        rt: jitRuntime,
         promiseCounter: 0,
         data: {},
         nullErrors: [],
@@ -592,22 +595,18 @@ function compileDeferredField(
       } catch (err) {
         ${getErrorDestination(fieldType)}.push(${executionError});
       }
-      if (${isPromiseInliner("__value")}) {
-      ${promiseStarted()}
-       __value.then(result => {
-        ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${resultParentPath}, result, ${parentIndexes});
-        ${promiseDone()}
-       }, err => {
-        if (err) {
-          ${getErrorDestination(fieldType)}.push(${executionError});
-        } else {
-          ${getErrorDestination(fieldType)}.push(${emptyError});
+      ${GLOBAL_RUNTIME_NAME}.handleResolverResult(${GLOBAL_EXECUTION_CONTEXT}, __value,
+        result => {
+          ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${resultParentPath}, result, ${parentIndexes});
+        },
+        err => {
+          if (err) {
+            ${getErrorDestination(fieldType)}.push(${executionError});
+          } else {
+            ${getErrorDestination(fieldType)}.push(${emptyError});
+          }
         }
-        ${promiseDone()}
-       });
-      } else {
-        ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${resultParentPath}, __value, ${parentIndexes});
-      }
+      );
     }`;
   context.hoistedFunctions.push(`
     function ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${GLOBAL_PARENT_NAME}, ${jsFieldName}, ${parentIndexes}) {
@@ -1163,58 +1162,23 @@ function compileListType(
   const parentIndexes = getParentArgIndexes(context);
   listContext.hoistedFunctions.push(`
   function ${safeMapHandler}(${GLOBAL_EXECUTION_CONTEXT}, __currentItem, idx${newDepth}, resultArray, ${parentIndexes}) {
-    if (${isPromiseInliner("__currentItem")}) {
-      ${promiseStarted()}
-      __currentItem.then(result => {
+    ${GLOBAL_RUNTIME_NAME}.handleListItemResult(${GLOBAL_EXECUTION_CONTEXT}, __currentItem,
+      result => {
         ${itemHandler}(${GLOBAL_EXECUTION_CONTEXT}, resultArray, result, ${childIndexes});
-        ${promiseDone()}
-      }, err => {
+      },
+      err => {
         resultArray.push(null);
         if (err) {
           ${getErrorDestination(fieldType)}.push(${executionError});
         } else {
           ${getErrorDestination(fieldType)}.push(${emptyError});
         }
-        ${promiseDone()}
-      });
-    } else {
-       ${itemHandler}(${GLOBAL_EXECUTION_CONTEXT}, resultArray, __currentItem, ${childIndexes});
-    }
+      }
+    );
   }
   `);
   return `(typeof ${name} === "string" || typeof ${name}[Symbol.iterator] !== "function") ?  ${errorCase} :
   ${GLOBAL_SAFE_MAP_NAME}(${GLOBAL_EXECUTION_CONTEXT}, ${name}, ${safeMapHandler}, ${parentIndexes})`;
-}
-
-/**
- * Implements a generic map operation for any iterable.
- *
- * If the iterable is not valid, null is returned.
- * @param context
- * @param {Iterable<any> | string} iterable possible iterable
- * @param {(a: any) => any} cb callback that receives the item being iterated
- * @param idx
- * @returns {any[]} a new array with the result of the callback
- */
-function safeMap(
-  context: ExecutionContext,
-  iterable: Iterable<any> | string,
-  cb: (
-    context: ExecutionContext,
-    a: any,
-    index: number,
-    resultArray: any[],
-    ...idx: number[]
-  ) => any,
-  ...idx: number[]
-): any[] {
-  let index = 0;
-  const result: any[] = [];
-  for (const a of iterable) {
-    cb(context, a, index, result, ...idx);
-    ++index;
-  }
-  return result;
 }
 
 const MAGIC_MINUS_INFINITY =
@@ -1427,7 +1391,7 @@ export function isPromise(value: any): value is Promise<any> {
 }
 
 export function isPromiseInliner(value: string): string {
-  return `${value} != null && typeof ${value} === "object" && typeof ${value}.then === "function"`;
+  return `${GLOBAL_RUNTIME_NAME}.isPromise(${value})`;
 }
 
 /**
@@ -1682,22 +1646,6 @@ function getSerializerName(name: string) {
   return name + "Serializer";
 }
 
-function promiseStarted() {
-  return `
-     // increase the promise counter
-     ++${GLOBAL_PROMISE_COUNTER};
-  `;
-}
-
-function promiseDone() {
-  return `
-    --${GLOBAL_PROMISE_COUNTER};
-    if (${GLOBAL_PROMISE_COUNTER} === 0) {
-      ${GLOBAL_RESOLVE}(${GLOBAL_EXECUTION_CONTEXT});
-    }
-  `;
-}
-
 function normalizeErrors(err: Error[] | Error): GraphQLError[] {
   if (Array.isArray(err)) {
     return err.map((e) => normalizeError(e));
@@ -1872,7 +1820,6 @@ function createBoundSubscribe(
         rootValue,
         context,
         variables: parsedVariables.coerced,
-        safeMap,
         inspect,
         GraphQLError: GraphqlJitError,
         resolvers,
@@ -1881,6 +1828,7 @@ function createBoundSubscribe(
         serializers,
         resolveInfos,
         trimmer,
+        rt: jitRuntime,
         promiseCounter: 0,
         nullErrors: [],
         errors: [],

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -957,18 +957,18 @@ function compileObjectType(
       fieldCondition = "true";
     }
 
-    body(`
-      (
-        ${fieldCondition}
-      )
-    `);
+    const alwaysIncluded = fieldCondition === "true";
+
+    if (!alwaysIncluded) {
+      body(`(${fieldCondition})`);
+    }
 
     // Inline __typename
     // No need to call a resolver for typename
     if (field === TypeNameMetaFieldDef) {
-      // type.name if field is included else undefined - to remove from object
-      // during serialization
-      body(`? "${type.name}" : undefined,`);
+      body(
+        alwaysIncluded ? `"${type.name}",` : `? "${type.name}" : undefined,`
+      );
       continue;
     }
 
@@ -992,34 +992,29 @@ function compileObjectType(
         args: getArgumentDefs(field, fieldNodes[0])
       });
       context.resolvers[getResolverName(type.name, field.name)] = resolver;
-      body(
-        `
-          ? (
-              ${SAFETY_CHECK_PREFIX}${context.deferred.length - 1} = true,
-              null
-            )
-          : (
-              ${SAFETY_CHECK_PREFIX}${context.deferred.length - 1} = false,
-              undefined
-            )
-        `
-      );
+      const idx = context.deferred.length - 1;
+      if (alwaysIncluded) {
+        body(`(${SAFETY_CHECK_PREFIX}${idx} = true, null)`);
+      } else {
+        body(
+          `? (${SAFETY_CHECK_PREFIX}${idx} = true, null) : (${SAFETY_CHECK_PREFIX}${idx} = false, undefined)`
+        );
+      }
     } else {
-      // if included
-      body("?");
-      body(
-        compileType(
-          context,
-          type,
-          field.type,
-          fieldNodes,
-          originPaths.concat(field.name),
-          destinationPaths.concat(name),
-          addPath(responsePath, name)
-        )
+      const compiledFieldType = compileType(
+        context,
+        type,
+        field.type,
+        fieldNodes,
+        originPaths.concat(field.name),
+        destinationPaths.concat(name),
+        addPath(responsePath, name)
       );
-      // if not included
-      body(": undefined");
+      if (alwaysIncluded) {
+        body(compiledFieldType);
+      } else {
+        body(`? ${compiledFieldType} : undefined`);
+      }
     }
     // End object property
     body(",");

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,76 +1,34 @@
 import { type ExecutionContext } from "./execution";
 
-export const GLOBAL_RUNTIME_NAME = "__rt";
+type Serializer = (
+  c: ExecutionContext,
+  v: any,
+  onError: any,
+  ...idx: number[]
+) => any;
 
-export interface JitRuntime {
-  isPromise(value: unknown): boolean;
-  checkNonNullLeaf(
-    ctx: ExecutionContext,
-    value: unknown,
-    dest: any[],
-    nullMsg: string,
-    locs: any,
-    path: any,
-    capStack: boolean,
-    serialize: (
-      c: ExecutionContext,
-      v: any,
-      onError: any,
-      ...idx: number[]
-    ) => any,
-    errHandler: any,
-    ...parentIndexes: number[]
-  ): any;
-  checkNullableLeaf(
-    ctx: ExecutionContext,
-    value: unknown,
-    dest: any[],
-    locs: any,
-    path: any,
-    capStack: boolean,
-    serialize: (
-      c: ExecutionContext,
-      v: any,
-      onError: any,
-      ...idx: number[]
-    ) => any,
-    errHandler: any,
-    ...parentIndexes: number[]
-  ): any;
-  callResolver(
-    ctx: ExecutionContext,
-    call: () => unknown,
-    onSuccess: (result: unknown) => void,
-    onError: (err: unknown) => void
-  ): void;
-  handleResolverResult(
-    ctx: ExecutionContext,
-    value: unknown,
-    onSuccess: (result: unknown) => void,
-    onError: (err: unknown) => void
-  ): void;
-  handleListItemResult(
-    ctx: ExecutionContext,
-    item: unknown,
-    onSuccess: (result: unknown) => void,
-    onError: (err: unknown) => void
-  ): void;
-  finalizeResult(ctx: ExecutionContext): Promise<unknown> | undefined;
-  safeMap(
-    context: ExecutionContext,
-    iterable: Iterable<unknown> | string,
-    cb: (
-      context: ExecutionContext,
-      a: unknown,
-      index: number,
-      resultArray: unknown[],
-      ...idx: number[]
-    ) => void,
-    ...idx: number[]
-  ): unknown[];
+function resolvePromise(
+  ctx: ExecutionContext,
+  promise: Promise<unknown>,
+  onSuccess: (result: unknown) => void,
+  onError: (err: unknown) => void
+): void {
+  ++ctx.promiseCounter;
+  promise.then(
+    (result) => {
+      onSuccess(result);
+      --ctx.promiseCounter;
+      if (ctx.promiseCounter === 0) ctx.resolve!(ctx);
+    },
+    (err) => {
+      onError(err);
+      --ctx.promiseCounter;
+      if (ctx.promiseCounter === 0) ctx.resolve!(ctx);
+    }
+  );
 }
 
-export const jitRuntime: JitRuntime = {
+export const jitRuntime = {
   isPromise(value: unknown): boolean {
     return (
       value != null &&
@@ -80,17 +38,17 @@ export const jitRuntime: JitRuntime = {
   },
 
   checkNonNullLeaf(
-    ctx,
-    value,
-    dest,
-    nullMsg,
-    locs,
-    path,
-    capStack,
-    serialize,
-    errHandler,
-    ...parentIndexes
-  ) {
+    ctx: ExecutionContext,
+    value: unknown,
+    dest: any[],
+    nullMsg: string,
+    locs: any,
+    path: any,
+    capStack: boolean,
+    serialize: Serializer,
+    errHandler: any,
+    ...parentIndexes: number[]
+  ): any {
     const GQLError = ctx.GraphQLError as any;
     if (value == null) {
       dest.push(new GQLError(nullMsg, locs, path, undefined, capStack));
@@ -98,13 +56,7 @@ export const jitRuntime: JitRuntime = {
     }
     if (value instanceof Error) {
       dest.push(
-        new GQLError(
-          value.message != null ? value.message : value,
-          locs,
-          path,
-          value,
-          capStack
-        )
+        new GQLError(value.message ?? value, locs, path, value, capStack)
       );
       return null;
     }
@@ -112,34 +64,33 @@ export const jitRuntime: JitRuntime = {
   },
 
   checkNullableLeaf(
-    ctx,
-    value,
-    dest,
-    locs,
-    path,
-    capStack,
-    serialize,
-    errHandler,
-    ...parentIndexes
-  ) {
-    const GQLError = ctx.GraphQLError as any;
+    ctx: ExecutionContext,
+    value: unknown,
+    dest: any[],
+    locs: any,
+    path: any,
+    capStack: boolean,
+    serialize: Serializer,
+    errHandler: any,
+    ...parentIndexes: number[]
+  ): any {
     if (value == null) return null;
+    const GQLError = ctx.GraphQLError as any;
     if (value instanceof Error) {
       dest.push(
-        new GQLError(
-          value.message != null ? value.message : value,
-          locs,
-          path,
-          value,
-          capStack
-        )
+        new GQLError(value.message ?? value, locs, path, value, capStack)
       );
       return null;
     }
     return serialize(ctx, value, errHandler, ...parentIndexes);
   },
 
-  callResolver(ctx, call, onSuccess, onError) {
+  callResolver(
+    ctx: ExecutionContext,
+    call: () => unknown,
+    onSuccess: (result: unknown) => void,
+    onError: (err: unknown) => void
+  ): void {
     let value: unknown;
     try {
       value = call();
@@ -151,49 +102,27 @@ export const jitRuntime: JitRuntime = {
     this.handleResolverResult(ctx, value, onSuccess, onError);
   },
 
-  handleResolverResult(ctx, value, onSuccess, onError) {
+  handleResolverResult(
+    ctx: ExecutionContext,
+    value: unknown,
+    onSuccess: (result: unknown) => void,
+    onError: (err: unknown) => void
+  ): void {
     if (this.isPromise(value)) {
-      ++ctx.promiseCounter;
-      (value as Promise<unknown>).then(
-        (result) => {
-          onSuccess(result);
-          --ctx.promiseCounter;
-          if (ctx.promiseCounter === 0) {
-            ctx.resolve!(ctx);
-          }
-        },
-        (err) => {
-          onError(err);
-          --ctx.promiseCounter;
-          if (ctx.promiseCounter === 0) {
-            ctx.resolve!(ctx);
-          }
-        }
-      );
+      resolvePromise(ctx, value as Promise<unknown>, onSuccess, onError);
     } else {
       onSuccess(value);
     }
   },
 
-  handleListItemResult(ctx, item, onSuccess, onError) {
+  handleListItemResult(
+    ctx: ExecutionContext,
+    item: unknown,
+    onSuccess: (result: unknown) => void,
+    onError: (err: unknown) => void
+  ): void {
     if (this.isPromise(item)) {
-      ++ctx.promiseCounter;
-      (item as Promise<unknown>).then(
-        (result) => {
-          onSuccess(result);
-          --ctx.promiseCounter;
-          if (ctx.promiseCounter === 0) {
-            ctx.resolve!(ctx);
-          }
-        },
-        (err) => {
-          onError(err);
-          --ctx.promiseCounter;
-          if (ctx.promiseCounter === 0) {
-            ctx.resolve!(ctx);
-          }
-        }
-      );
+      resolvePromise(ctx, item as Promise<unknown>, onSuccess, onError);
     } else {
       onSuccess(item);
     }
@@ -208,7 +137,18 @@ export const jitRuntime: JitRuntime = {
     return undefined;
   },
 
-  safeMap(ctx, iterable, cb, ...idx) {
+  safeMap(
+    ctx: ExecutionContext,
+    iterable: Iterable<unknown> | string,
+    cb: (
+      context: ExecutionContext,
+      a: unknown,
+      index: number,
+      resultArray: unknown[],
+      ...idx: number[]
+    ) => void,
+    ...idx: number[]
+  ): unknown[] {
     let index = 0;
     const result: unknown[] = [];
     for (const a of iterable as Iterable<unknown>) {
@@ -218,3 +158,5 @@ export const jitRuntime: JitRuntime = {
     return result;
   }
 };
+
+export type JitRuntime = typeof jitRuntime;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4,6 +4,12 @@ export const GLOBAL_RUNTIME_NAME = "__rt";
 
 export interface JitRuntime {
   isPromise(value: unknown): boolean;
+  callResolver(
+    ctx: ExecutionContext,
+    call: () => unknown,
+    onSuccess: (result: unknown) => void,
+    onError: (err: unknown) => void
+  ): void;
   handleResolverResult(
     ctx: ExecutionContext,
     value: unknown,
@@ -16,6 +22,7 @@ export interface JitRuntime {
     onSuccess: (result: unknown) => void,
     onError: (err: unknown) => void
   ): void;
+  finalizeResult(ctx: ExecutionContext): Promise<unknown> | undefined;
   safeMap(
     context: ExecutionContext,
     iterable: Iterable<unknown> | string,
@@ -37,6 +44,18 @@ export const jitRuntime: JitRuntime = {
       typeof value === "object" &&
       typeof (value as any).then === "function"
     );
+  },
+
+  callResolver(ctx, call, onSuccess, onError) {
+    let value: unknown;
+    try {
+      value = call();
+    } catch (err) {
+      onError(err);
+      onSuccess(null);
+      return;
+    }
+    this.handleResolverResult(ctx, value, onSuccess, onError);
   },
 
   handleResolverResult(ctx, value, onSuccess, onError) {
@@ -85,6 +104,15 @@ export const jitRuntime: JitRuntime = {
     } else {
       onSuccess(item);
     }
+  },
+
+  finalizeResult(ctx: ExecutionContext): Promise<unknown> | undefined {
+    if (ctx.promiseCounter > 0) {
+      return new Promise((resolve) => {
+        ctx.resolve = resolve;
+      });
+    }
+    return undefined;
   },
 
   safeMap(ctx, iterable, cb, ...idx) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4,6 +4,39 @@ export const GLOBAL_RUNTIME_NAME = "__rt";
 
 export interface JitRuntime {
   isPromise(value: unknown): boolean;
+  checkNonNullLeaf(
+    ctx: ExecutionContext,
+    value: unknown,
+    dest: any[],
+    nullMsg: string,
+    locs: any,
+    path: any,
+    capStack: boolean,
+    serialize: (
+      c: ExecutionContext,
+      v: any,
+      onError: any,
+      ...idx: number[]
+    ) => any,
+    errHandler: any,
+    ...parentIndexes: number[]
+  ): any;
+  checkNullableLeaf(
+    ctx: ExecutionContext,
+    value: unknown,
+    dest: any[],
+    locs: any,
+    path: any,
+    capStack: boolean,
+    serialize: (
+      c: ExecutionContext,
+      v: any,
+      onError: any,
+      ...idx: number[]
+    ) => any,
+    errHandler: any,
+    ...parentIndexes: number[]
+  ): any;
   callResolver(
     ctx: ExecutionContext,
     call: () => unknown,
@@ -44,6 +77,66 @@ export const jitRuntime: JitRuntime = {
       typeof value === "object" &&
       typeof (value as any).then === "function"
     );
+  },
+
+  checkNonNullLeaf(
+    ctx,
+    value,
+    dest,
+    nullMsg,
+    locs,
+    path,
+    capStack,
+    serialize,
+    errHandler,
+    ...parentIndexes
+  ) {
+    const GQLError = ctx.GraphQLError as any;
+    if (value == null) {
+      dest.push(new GQLError(nullMsg, locs, path, undefined, capStack));
+      return null;
+    }
+    if (value instanceof Error) {
+      dest.push(
+        new GQLError(
+          value.message != null ? value.message : value,
+          locs,
+          path,
+          value,
+          capStack
+        )
+      );
+      return null;
+    }
+    return serialize(ctx, value, errHandler, ...parentIndexes);
+  },
+
+  checkNullableLeaf(
+    ctx,
+    value,
+    dest,
+    locs,
+    path,
+    capStack,
+    serialize,
+    errHandler,
+    ...parentIndexes
+  ) {
+    const GQLError = ctx.GraphQLError as any;
+    if (value == null) return null;
+    if (value instanceof Error) {
+      dest.push(
+        new GQLError(
+          value.message != null ? value.message : value,
+          locs,
+          path,
+          value,
+          capStack
+        )
+      );
+      return null;
+    }
+    return serialize(ctx, value, errHandler, ...parentIndexes);
   },
 
   callResolver(ctx, call, onSuccess, onError) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,99 @@
+import { type ExecutionContext } from "./execution";
+
+export const GLOBAL_RUNTIME_NAME = "__rt";
+
+export interface JitRuntime {
+  isPromise(value: unknown): boolean;
+  handleResolverResult(
+    ctx: ExecutionContext,
+    value: unknown,
+    onSuccess: (result: unknown) => void,
+    onError: (err: unknown) => void
+  ): void;
+  handleListItemResult(
+    ctx: ExecutionContext,
+    item: unknown,
+    onSuccess: (result: unknown) => void,
+    onError: (err: unknown) => void
+  ): void;
+  safeMap(
+    context: ExecutionContext,
+    iterable: Iterable<unknown> | string,
+    cb: (
+      context: ExecutionContext,
+      a: unknown,
+      index: number,
+      resultArray: unknown[],
+      ...idx: number[]
+    ) => void,
+    ...idx: number[]
+  ): unknown[];
+}
+
+export const jitRuntime: JitRuntime = {
+  isPromise(value: unknown): boolean {
+    return (
+      value != null &&
+      typeof value === "object" &&
+      typeof (value as any).then === "function"
+    );
+  },
+
+  handleResolverResult(ctx, value, onSuccess, onError) {
+    if (this.isPromise(value)) {
+      ++ctx.promiseCounter;
+      (value as Promise<unknown>).then(
+        (result) => {
+          onSuccess(result);
+          --ctx.promiseCounter;
+          if (ctx.promiseCounter === 0) {
+            ctx.resolve!(ctx);
+          }
+        },
+        (err) => {
+          onError(err);
+          --ctx.promiseCounter;
+          if (ctx.promiseCounter === 0) {
+            ctx.resolve!(ctx);
+          }
+        }
+      );
+    } else {
+      onSuccess(value);
+    }
+  },
+
+  handleListItemResult(ctx, item, onSuccess, onError) {
+    if (this.isPromise(item)) {
+      ++ctx.promiseCounter;
+      (item as Promise<unknown>).then(
+        (result) => {
+          onSuccess(result);
+          --ctx.promiseCounter;
+          if (ctx.promiseCounter === 0) {
+            ctx.resolve!(ctx);
+          }
+        },
+        (err) => {
+          onError(err);
+          --ctx.promiseCounter;
+          if (ctx.promiseCounter === 0) {
+            ctx.resolve!(ctx);
+          }
+        }
+      );
+    } else {
+      onSuccess(item);
+    }
+  },
+
+  safeMap(ctx, iterable, cb, ...idx) {
+    let index = 0;
+    const result: unknown[] = [];
+    for (const a of iterable as Iterable<unknown>) {
+      cb(ctx, a, index, result, ...idx);
+      ++index;
+    }
+    return result;
+  }
+};


### PR DESCRIPTION
Profiling medium to large production compiled queries shows an average memory of 10MB per compiledQuery. This creates heap pressure and gc dominated event-loop. In this PR, we create a shared runtime module, extract common boilerplate code that exists in every query, and group common handlers into smaller versions to reduce the 10MB avg to 3.2MB for the same set of queries we started with.

#### Optimizations: 

1. Shared runtime extracts boilerplate code like promise handling, null checks, error checks, safeMap handling, resolver try catch into single module level object. We expose `ExecutionContext.rt` instead of inlining these patterns for every query, and these are shared across all compiled queries. 
2. Trivial skip/include ternaries are generated even for fields with no skip / include directives - `true ? value : undefined`. We eliminate this.
3. When the same field appears at the same query path multiple times within a single compilation, the error handling functions were simply duplicates. We deduplicate them in compilation context keyed on function body. This is most prominent in unions with N concrete types. 
4. Abstract types contain trivial cases that only include __typename field. Here, we generate a switch case per concrete type even when the bodies differ only in typename string literal. So, we add a precomputed finalType variable so that concrete types with no deferred resolvers can be grouped into a single case. A union type with a N (around 50 or 100) cases and handling only 2-3 cases in a query benefit a lot.

Measured on 120 queries, 

Avg per query: 
- Before: 10+ MB
- After: 3+ MB

Total:
- Before: 1200+ MB
- After: 380+ MB
