### PR TITLE
fix: scope escape bug of finalType

### DIFF
--- a/src/__tests__/abstract.test.ts
+++ b/src/__tests__/abstract.test.ts
@@ -732,6 +732,76 @@ describe("Abstract type trivial case deduplication", () => {
     );
   });
 
+  test("non-trivial union member with async resolver returning typed object with __typename", async () => {
+    const Product = new GraphQLObjectType({
+      name: "Product",
+      fields: {
+        __typename: { type: GraphQLString },
+        name: { type: GraphQLString }
+      }
+    });
+
+    const TrivialA = new GraphQLObjectType({
+      name: "TrivialA",
+      fields: { id: { type: GraphQLID } }
+    });
+
+    const NonTrivial = new GraphQLObjectType({
+      name: "NonTrivial",
+      fields: {
+        id: { type: GraphQLID },
+        product: {
+          type: Product,
+          resolve: (obj) => Promise.resolve({ name: obj.productName })
+        }
+      }
+    });
+
+    const Feed = new GraphQLUnionType({
+      name: "Feed",
+      types: [TrivialA, NonTrivial],
+      resolveType: (obj) => obj.__type
+    });
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: "Query",
+        fields: {
+          feed: {
+            type: new GraphQLList(Feed),
+            resolve: () => [
+              { __type: "TrivialA", id: "1" },
+              { __type: "NonTrivial", id: "2", productName: "Widget" }
+            ]
+          }
+        }
+      })
+    });
+
+    const document = parse(`{
+      feed {
+        __typename
+        ... on NonTrivial {
+          id
+          product { __typename name }
+        }
+      }
+    }`);
+    const compiled = compileQuery(schema, document, "");
+    if (!isCompiledQuery(compiled)) throw new Error("compile failed");
+
+    const result = await compiled.query(undefined, undefined, undefined);
+    expect(result.errors).toBeUndefined();
+    expect(result.data!.feed).toEqual([
+      { __typename: "TrivialA" },
+      {
+        __typename: "NonTrivial",
+        id: "2",
+        product: { __typename: "Product", name: "Widget" }
+      }
+    ]);
+  });
+
   // A union where some members are trivial (__typename only, grouped into a
   // shared case) and some are non-trivial (have resolver-backed fields, get
   // individual cases). Both paths must execute correctly in the same query.

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -865,6 +865,12 @@ function compileObjectType(
   fieldMap: FieldsAndNodes,
   alwaysDefer: boolean
 ): string {
+  // trivialTypeNameVar applies only to __typename of this (current) type.
+  // Clear it on context so nested field compilations and deferred resolver
+  // handler sub-contexts don't reference finalType outside its switch scope.
+  const trivialTypeNameVar = context.trivialTypeNameVar;
+  context.trivialTypeNameVar = undefined;
+
   const body = genFn();
 
   // Begin object compilation paren
@@ -971,7 +977,7 @@ function compileObjectType(
     // Inline __typename
     // No need to call a resolver for typename
     if (field === TypeNameMetaFieldDef) {
-      const typenameValue = context.trivialTypeNameVar ?? `"${type.name}"`;
+      const typenameValue = trivialTypeNameVar ?? `"${type.name}"`;
       body(
         alwaysIncluded ? `${typenameValue},` : `? ${typenameValue} : undefined,`
       );


### PR DESCRIPTION
fix for #279 

In the previous pr #277 , 

1. compileAbstractType compiles each type with `context.trivialTypeNameVar = "finalType"` so that trivial cases can share a single switch body.
2. but this context gets spread elsewhere in hoisted functions and generates `{ __typename: finalType, ...`  and results in a Reference Error during the onSuccess of resolver's promise. 
3. This happens after ++promiseCounter but before --promiseCounter. The counter was permanently stuck above 0. 

The fix is to set it to a local variable and immediately clear it in the context.