### PR TITLE
support graphql-js v17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22, 24]
-        graphql-version: [15, 16, 17.0.0-alpha.9]
+        node-version: [22, 24, 26]
+        graphql-version: [15, 16, 17]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     needs: lint # Only run tests if linting passes
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [22, 24, 26]
         graphql-version: [15, 16, 17]

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "globals": "^15.9.0",
-    "graphql": "^16.8.0",
+    "graphql": "^17.0.1",
     "jest": "^29.7.0",
     "lint-staged": "^14.0.1",
     "prettier": "^3.0.3",

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -401,14 +401,19 @@ describe("Execute: Handles execution with a complex schema", () => {
 
   test("executes IntrospectionQuery", () => {
     const queryAST = parse(
-      getIntrospectionQuery({ descriptions: true, inputValueDeprecation: true })
+      getIntrospectionQuery({
+        descriptions: true,
+        inputValueDeprecation: true
+      })
     );
     const result = executeQuery(
       BlogSchema,
       queryAST
     ) as ExecutionResult<IntrospectionQuery>;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
     const schemaFromIntrospection = buildClientSchema(result.data!);
+
     expect(printSchema(schemaFromIntrospection)).toEqual(
       printSchema(BlogSchema)
     );

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -36,7 +36,9 @@ import { type CompilationContext, GLOBAL_VARIABLES_NAME } from "./execution.js";
 import createInspect from "./inspect.js";
 import {
   coerceInputLiteral,
+  getDefaultValue,
   getGraphQLErrorOptions,
+  hasDefaultValue,
   resolveFieldDef
 } from "./compat.js";
 
@@ -766,9 +768,9 @@ export function getArgumentDefs(
   const argNodeMap = keyMap(argNodes, (arg) => arg.name.value);
   for (const argDef of argDefs) {
     const name = argDef.name;
-    if (argDef.defaultValue !== undefined) {
-      // Set the coerced value to the default
-      values[name] = argDef.defaultValue;
+    if (hasDefaultValue(argDef)) {
+      // handle both v16 defaultValue and v17 default.value
+      values[name] = getDefaultValue(argDef);
     }
     const argType = argDef.type;
     const argumentNode = argNodeMap[name];
@@ -913,8 +915,8 @@ export function valueFromAST(
     const fieldNodes = keyMap(valueNode.fields, (field) => field.name.value);
     const fields = Object.values(type.getFields());
     for (const field of fields) {
-      if (field.defaultValue !== undefined) {
-        coercedObj[field.name] = field.defaultValue;
+      if (hasDefaultValue(field)) {
+        coercedObj[field.name] = getDefaultValue(field);
       }
       const fieldNode = fieldNodes[field.name];
       if (!fieldNode) {

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -117,6 +117,31 @@ export function resolveFieldDef(
 }
 
 /**
+ * v17 introduces `arg.default = { value }` for SDL-built schemas.
+ * Programmatic schemas still use `arg.defaultValue`.
+ * This helper normalizes both to a single value.
+ */
+export function getDefaultValue(argOrField: {
+  defaultValue?: unknown;
+  default?: { value?: unknown; literal?: unknown };
+}): unknown {
+  if (argOrField.default !== undefined) {
+    // v17 SDL-built default — `.value` holds the JS value
+    return (argOrField.default as any).value;
+  }
+  return argOrField.defaultValue;
+}
+
+export function hasDefaultValue(argOrField: {
+  defaultValue?: unknown;
+  default?: { value?: unknown; literal?: unknown };
+}): boolean {
+  return (
+    argOrField.default !== undefined || argOrField.defaultValue !== undefined
+  );
+}
+
+/**
  * v17 deprecates parseLiteral in favor of coerceInputLiteral for custom scalars
  * However, custom scalars may still only define parseLiteral, so we check
  * for the method's existence rather than just the version.
@@ -132,4 +157,14 @@ export function coerceInputLiteral(
   }
 
   return (type as any).parseLiteral(valueNode, {});
+}
+
+/**
+ * V17 removes execution context
+ * This is a minimal interface to support the execution context for v16 and v17+
+ */
+export interface ExecutionContext {
+  errors: Array<GraphQLError> | undefined;
+  completed: boolean;
+  errorPropagation: boolean;
 }

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -36,7 +36,7 @@ import {
   type OperationDefinitionNode,
   type GraphQLTypeResolver
 } from "graphql";
-import { type ExecutionContext as GraphQLContext } from "graphql/execution/execute.js";
+import { type ExecutionContext as GraphQLContext } from "./compat.js";
 import { pathToArray } from "graphql/jsutils/Path.js";
 import {
   addPath,

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -21,6 +21,7 @@ import {
 } from "graphql";
 import { addPath, computeLocations, type ObjectPath } from "./ast.js";
 import { GraphQLError as GraphQLJITError } from "./error.js";
+import { getDefaultValue, hasDefaultValue } from "./compat.js";
 import createInspect from "./inspect.js";
 
 const inspect = createInspect();
@@ -378,7 +379,7 @@ function generateInput(
           field.type,
           field.name,
           hasValueName,
-          field.defaultValue,
+          hasDefaultValue(field) ? getDefaultValue(field) : undefined,
           false
         )}
       `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4651,7 +4651,7 @@ __metadata:
     fast-json-stringify: "npm:^5.16.1"
     generate-function: "npm:^2.3.1"
     globals: "npm:^15.9.0"
-    graphql: "npm:^16.8.0"
+    graphql: "npm:^17.0.1"
     jest: "npm:^29.7.0"
     lint-staged: "npm:^14.0.1"
     lodash.memoize: "npm:^4.1.2"
@@ -4666,10 +4666,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"graphql@npm:^16.8.0":
-  version: 16.12.0
-  resolution: "graphql@npm:16.12.0"
-  checksum: 10c0/b6fffa4e8a4e4a9933ebe85e7470b346dbf49050c1a482fac5e03e4a1a7bed2ecd3a4c97e29f04457af929464bc5e4f2aac991090c2f320111eef26e902a5c75
+"graphql@npm:^17.0.1":
+  version: 17.0.1
+  resolution: "graphql@npm:17.0.1"
+  checksum: 10c0/95e4766eefa97bbc37cb4452527d24e12068f170e03c564611a3911f30a77361dfcfbdbfeea00f643c82585c02312c1f41ba6a6263049996d279c49951454980
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- drop Node 20, test against node 22,24,26
- Support graphql-js stable release v17
- set default dev version of graphql-js to v17