### PR TITLE
fix: tsconfig for node and jest globals

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "strictPropertyInitialization": true,
     "esModuleInterop": true,
     "lib": ["esnext.asynciterable", "ES2022"],
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./types", "./node_modules/@types"],
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*", "types/**/*", "tsup.config.ts"]
 }


### PR DESCRIPTION
Editor shows red squiggly lines for NodeJS and Jest globals. Add these types to tsconfig.